### PR TITLE
fix for jvm.options not capturing all args, and user agent set when down...

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ After you have set the license acceptance environment variables, use the followi
 cf push --buildpack https://github.com/cloudfoundry/ibm-websphere-liberty-buildpack.git
 ```
 
-For further details on the options available for deploying your applications see [options][].
+* For further details on the options available for deploying your applications see [options][].
+* For further details on tuning the applications JVM see [tuning options][].
 
 ## Forking the buildpack   
 If you wish to fork the buildpack and host your own binaries, then complete the following:
@@ -77,6 +78,7 @@ bundle install --gemfile Gemfile.rubymine-debug
 [Pull requests]: http://help.github.com/send-pull-requests
 [example]: docs/installation.md#setting-up-your-web-server
 [options]: docs/server-xml-options.md
+[tuning options]: docs/tuning.md
 [Repositories]: docs/util-repositories.md
 [ibmjdk.yml]: config/ibmjdk.yml
 [liberty.yml]: config/liberty.yml

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -1,0 +1,16 @@
+Tuning the Liberty Profile in the Cloud
+========================================
+
+You can tune parameters and attributes of the Liberty profile.
+
+## Tuning the JVM
+Tuning the JVM is a most important tuning step whether you configure a development or production environment.
+When you tune the JVM for the Liberty profile, create a jvm.options file in your server directory. 
+You can specify each of the JVM arguments that you want to use, one option per line. An example of the jvm.options file is as follows:
+
+```
+-Xms50m
+-Xmx256m
+```
+
+For a development environment, you might be interested in faster server startup, so consider setting the minimum heap size to a small value, and the maximum heap size to whatever value is needed for your application. For a production environment, setting the minimum heap size and maximum heap size to the same value can provide the best performance by avoiding heap expansion and contraction.

--- a/lib/liberty_buildpack/container/liberty.rb
+++ b/lib/liberty_buildpack/container/liberty.rb
@@ -79,7 +79,6 @@ module LibertyBuildpack::Container
         raise
       end
 
-      jvm_options
       download_liberty
       update_server_xml
       link_application
@@ -98,6 +97,7 @@ module LibertyBuildpack::Container
       java_home_string = "JAVA_HOME=\"$PWD/#{@java_home}\""
       start_script_string = ContainerUtils.space(File.join(LIBERTY_HOME, 'bin', 'server'))
       start_script_string << ContainerUtils.space('run')
+      jvm_options
       server_name_string = ContainerUtils.space(server_name)
       "#{create_vars_string}#{java_home_string}#{start_script_string}#{server_name_string}"
     end
@@ -105,14 +105,14 @@ module LibertyBuildpack::Container
     private
 
     def jvm_options
-      jvm_options_path = File.join(@app_dir, 'jvm.options')
-      if File.exist?(jvm_options_path)
-        puts 'Using jvm.options provided.'
-      else
-        jvm_options_file = File.new(jvm_options_path, 'w')
+      jvm_options_src = File.join(@app_dir, 'jvm.options')
+      unless File.exist?(jvm_options_src)
+        jvm_options_file = File.new(jvm_options_src, 'w')
         jvm_options_file.puts(@java_opts)
         jvm_options_file.close
       end
+      jvm_options_dest = Liberty.server_xml_directory(@app_dir)
+      system "mv #{jvm_options_src} #{File.expand_path(jvm_options_dest, File.dirname(__FILE__))}" unless jvm_options_dest.nil?
     end
 
     def minify?
@@ -348,6 +348,15 @@ module LibertyBuildpack::Container
         raise "Incorrect number of servers to deploy (expecting exactly one): #{candidates}"
       end
       candidates.any? ? candidates[0] : nil
+    end
+
+    def self.server_xml_directory(app_dir)
+      server_xml_dest = File.join(app_dir, LIBERTY_HOME, USR_PATH, '**/server.xml')
+      candidates = Dir.glob(server_xml_dest)
+      if candidates.size > 1
+        raise "Incorrect number of servers to deploy (expecting exactly one): #{candidates}"
+      end
+      candidates.any? ? File.dirname(candidates[0]) : nil
     end
 
     def self.server_xml(app_dir)

--- a/lib/liberty_buildpack/util/download_cache.rb
+++ b/lib/liberty_buildpack/util/download_cache.rb
@@ -118,7 +118,7 @@ module LibertyBuildpack::Util
         rich_uri = URI(uri)
 
         Net::HTTP.start(rich_uri.host, rich_uri.port, use_ssl: use_ssl?(rich_uri)) do |http|
-          request = Net::HTTP::Get.new(rich_uri.request_uri)
+          request = Net::HTTP::Get.new(rich_uri.request_uri, { 'User-Agent' => 'liberty_buildpack' })
           http.request request do |response|
             write_response(filenames, response)
           end

--- a/spec/liberty_buildpack/container/liberty_spec.rb
+++ b/spec/liberty_buildpack/container/liberty_spec.rb
@@ -141,32 +141,6 @@ module LibertyBuildpack::Container
         end
       end
 
-      it 'generate a jvm.options file if one is not provided' do
-        Dir.mktmpdir do |root|
-          Dir.mkdir File.join(root, 'WEB-INF')
-
-          LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
-          .and_return(LIBERTY_DETAILS)
-
-          LibertyBuildpack::Util::ApplicationCache.stub(:new).and_return(application_cache)
-          application_cache.stub(:get).with('test-liberty-uri').and_yield(File.open('spec/fixtures/wlp-stub.jar'))
-
-          library_directory = File.join(root, '.lib')
-          FileUtils.mkdir_p(library_directory)
-          Liberty.new(
-          app_dir: root,
-          lib_directory: library_directory,
-          configuration: {},
-          environment: {},
-          jvm_opts: %w(test-opt-2 test-opt-1),
-          license_ids: { 'IBM_LIBERTY_LICENSE' => '1234-ABCD' }
-          ).compile
-          jvm_options_file = File.join(root, 'jvm.options')
-          expect(File.exists?(jvm_options_file)).to be_true
-          expect(File.readlines(jvm_options_file).grep(/test-opt-1/).size > 0)
-        end
-      end
-
       it 'should extract Liberty from a JAR file' do
         Dir.mktmpdir do |root|
           Dir.mkdir File.join(root, 'WEB-INF')
@@ -561,6 +535,72 @@ module LibertyBuildpack::Container
     end
 
     describe 'release' do
+
+      it 'generate a jvm.options file if one is not provided' do
+        Dir.mktmpdir do |root|
+          Dir.mkdir File.join(root, 'WEB-INF')
+          FileUtils.mkdir_p File.join(root, '.liberty', 'usr', 'servers', 'defaultServer')
+          File.open(File.join(root, '.liberty', 'usr', 'servers', 'defaultServer', 'server.xml'), 'w') do |file|
+            file.write('your text')
+          end
+
+          LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
+          .and_return(LIBERTY_DETAILS)
+
+          LibertyBuildpack::Util::ApplicationCache.stub(:new).and_return(application_cache)
+          application_cache.stub(:get).with('test-liberty-uri').and_yield(File.open('spec/fixtures/wlp-stub.jar'))
+
+          library_directory = File.join(root, '.lib')
+          FileUtils.mkdir_p(library_directory)
+          Liberty.new(
+          app_dir: root,
+          lib_directory: library_directory,
+          configuration: {},
+          environment: {},
+          jvm_opts: %w(test-opt-2 test-opt-1),
+          license_ids: { 'IBM_LIBERTY_LICENSE' => '1234-ABCD' }
+          ).release
+
+          jvm_options_file = File.join(root, '.liberty', 'usr', 'servers', 'defaultServer', 'jvm.options')
+          expect(File.exists?(jvm_options_file)).to be_true
+          expect(File.readlines(jvm_options_file).grep(/test-opt-1/).size > 0)
+        end
+      end
+
+      it 'Use jvm.options file if one is provided.' do
+        Dir.mktmpdir do |root|
+          Dir.mkdir File.join(root, 'WEB-INF')
+          FileUtils.mkdir_p File.join(root, '.liberty', 'usr', 'servers', 'defaultServer')
+          File.open(File.join(root, '.liberty', 'usr', 'servers', 'defaultServer', 'server.xml'), 'w') do |file|
+            file.write('your text')
+          end
+          File.open(File.join(root, 'jvm.options'), 'w') do |file|
+            file.write('provided-opt-1')
+          end
+
+          LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
+          .and_return(LIBERTY_DETAILS)
+
+          LibertyBuildpack::Util::ApplicationCache.stub(:new).and_return(application_cache)
+          application_cache.stub(:get).with('test-liberty-uri').and_yield(File.open('spec/fixtures/wlp-stub.jar'))
+
+          library_directory = File.join(root, '.lib')
+          FileUtils.mkdir_p(library_directory)
+          Liberty.new(
+          app_dir: root,
+          lib_directory: library_directory,
+          configuration: {},
+          environment: {},
+          jvm_opts: '',
+          license_ids: { 'IBM_LIBERTY_LICENSE' => '1234-ABCD' }
+          ).release
+
+          jvm_options_file = File.join(root, '.liberty', 'usr', 'servers', 'defaultServer', 'jvm.options')
+          expect(File.exists?(jvm_options_file)).to be_true
+          expect(File.readlines(jvm_options_file).grep(/provided-opt-1/).size > 0)
+        end
+      end
+
       it 'should return correct execution command for the WEB-INF case' do
         LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
         .and_return(LIBERTY_VERSION)


### PR DESCRIPTION
A fix for the jvm.options file not capturing arguments from the release phase of the frameworks.
User agent has been set to "liberty_buildpack"
Tests to ensure that the jvm.options file is both generated and put into the right place if provided.
