### PR TITLE
Use webContainer to have a proper redirection between application pages.

### DIFF
--- a/lib/liberty_buildpack/container/liberty.rb
+++ b/lib/liberty_buildpack/container/liberty.rb
@@ -221,6 +221,7 @@ module LibertyBuildpack::Container
         server_xml_doc.context[:attribute_quote] = :quote
 
         update_http_endpoint(server_xml_doc)
+        update_web_container(server_xml_doc)
 
         include_file = REXML::Element.new('include', server_xml_doc.root)
         include_file.add_attribute('location', 'runtime-vars.xml')
@@ -269,6 +270,17 @@ module LibertyBuildpack::Container
       endpoint.add_attribute('host', '*')
       endpoint.add_attribute('httpPort', "${#{KEY_HTTP_PORT}}")
       endpoint.delete_attribute('httpsPort')
+    end
+
+    def update_web_container(server_xml_doc)
+      webcontainers = REXML::XPath.match(server_xml_doc, '/server/webContainer')
+      if webcontainers.empty?
+        webcontainer = REXML::Element.new('webContainer', server_xml_doc.root)
+      else
+        webcontainer = webcontainers[0]
+      end
+      webcontainer.add_attribute('trustHostHeaderPort', 'true')
+      webcontainer.add_attribute('extractHostHeaderPort', 'true')
     end
 
     def disable_welcome_page(server_xml_doc)

--- a/resources/liberty/server.xml
+++ b/resources/liberty/server.xml
@@ -16,6 +16,9 @@
         
 
     <include location="runtime-vars.xml" />
+
+    <webContainer trustHostHeaderPort="true" extractHostHeaderPort="true" />
+    
     <httpDispatcher enableWelcomePage="false"/>
 
     <logging consoleLogLevel="INFO"/>

--- a/spec/liberty_buildpack/container/liberty_spec.rb
+++ b/spec/liberty_buildpack/container/liberty_spec.rb
@@ -744,7 +744,41 @@ module LibertyBuildpack::Container
           expect(server_xml_contents.include? 'host="*"').to be_true
           expect(server_xml_contents.include? 'httpPort="${port}"').to be_true
           expect(server_xml_contents.include? 'httpsPort=').to be_false
+          expect(server_xml_contents).to match(/<webContainer extractHostHeaderPort='true' trustHostHeaderPort='true'\/>/)
           expect(File.exists?(droplet_yaml_file)).to be_false
+        end
+      end
+
+      it 'should update webContainer element if server.xml already contains one' do
+        Dir.mktmpdir do |root|
+          root = File.join(root, 'app')
+          FileUtils.mkdir_p File.join(root, 'wlp', 'usr', 'servers', 'myServer')
+          File.open(File.join(root, 'wlp', 'usr', 'servers', 'myServer', 'server.xml'), 'w') do |file|
+            file.write("<server><webContainer extractHostHeaderPort='false' trusted='false' /></server>")
+          end
+
+          LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
+          .and_return(LIBERTY_DETAILS)
+
+          LibertyBuildpack::Repository::ComponentIndex.stub(:new).and_return(component_index)
+          component_index.stub(:components).and_return({ 'liberty_core' => LIBERTY_SINGLE_DOWNLOAD_URI })
+
+          LibertyBuildpack::Util::ApplicationCache.stub(:new).and_return(application_cache)
+          application_cache.stub(:get).with(LIBERTY_SINGLE_DOWNLOAD_URI).and_yield(File.open('spec/fixtures/wlp-stub.tar.gz'))
+
+          Liberty.new(
+          app_dir: root,
+          configuration: {},
+          environment: {},
+          license_ids: { 'IBM_LIBERTY_LICENSE' => '1234-ABCD' }
+          ).compile
+
+          liberty_directory = File.join(root, '.liberty')
+          expect(Dir.exists?(liberty_directory)).to be_true
+
+          server_xml_file = File.join(root, 'wlp', 'usr', 'servers', 'myServer', 'server.xml')
+          server_xml_contents = File.read server_xml_file
+          expect(server_xml_contents).to match(/<webContainer extractHostHeaderPort="true" trustHostHeaderPort="true" trusted="false"\/>/)
         end
       end
 


### PR DESCRIPTION
This change is necessary for applications to use proper redirection using default port instead of an internal port it listens on a DEA.
