### PR TITLE
Reset $stderr,$stdout in 'after' method if they were altered in 'before'...

### DIFF
--- a/spec/liberty_buildpack/buildpack_spec.rb
+++ b/spec/liberty_buildpack/buildpack_spec.rb
@@ -57,6 +57,10 @@ module LibertyBuildpack
       $stderr = StringIO.new
     end
 
+    after do
+      $stderr = STDERR
+    end
+
     it 'should call detect on all components' do
       stub_container1.stub(:detect).and_return('stub-container-1')
       stub_container1.stub(:apps).and_return(['root/app1', 'root/app2'])

--- a/spec/liberty_buildpack/container/liberty_spec.rb
+++ b/spec/liberty_buildpack/container/liberty_spec.rb
@@ -37,6 +37,11 @@ module LibertyBuildpack::Container
       application_cache.stub(:get).and_yield(File.open('spec/fixtures/license.html'))
     end
 
+    after do
+      $stdout = STDOUT
+      $stderr = STDERR
+    end
+
     describe 'prepare applications' do
       it 'should extract all applications' do
         Dir.mktmpdir do |root|
@@ -1051,60 +1056,72 @@ module LibertyBuildpack::Container
         LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
         .and_return(LIBERTY_VERSION)
 
-        command = Liberty.new(
-        app_dir: 'spec/fixtures/container_liberty',
-        java_home: 'test-java-home',
-        java_opts: '',
-        configuration: {},
-        license_ids: {}
-        ).release
+        Dir.mktmpdir do |root|
+          FileUtils.cp_r('spec/fixtures/container_liberty', root)
+          command = Liberty.new(
+            app_dir: File.join(root, 'container_liberty'),
+            java_home: 'test-java-home',
+            java_opts: '',
+            configuration: {},
+            license_ids: {}
+          ).release
 
-        expect(command).to eq(".liberty/create_vars.rb .liberty/usr/servers/defaultServer/runtime-vars.xml && JAVA_HOME=\"$PWD/test-java-home\" .liberty/bin/server run defaultServer")
+          expect(command).to eq(".liberty/create_vars.rb .liberty/usr/servers/defaultServer/runtime-vars.xml && JAVA_HOME=\"$PWD/test-java-home\" .liberty/bin/server run defaultServer")
+        end
       end
 
       it 'should return correct execution command for the META-INF case' do
         LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
         .and_return(LIBERTY_VERSION)
 
-        command = Liberty.new(
-        app_dir: 'spec/fixtures/container_liberty_ear',
-        java_home: 'test-java-home',
-        java_opts: '',
-        configuration: {},
-        license_ids: {}
-        ).release
+        Dir.mktmpdir do |root|
+          FileUtils.cp_r('spec/fixtures/container_liberty_ear', root)
+          command = Liberty.new(
+            app_dir: File.join(root, 'container_liberty_ear'),
+            java_home: 'test-java-home',
+            java_opts: '',
+            configuration: {},
+            license_ids: {}
+          ).release
 
-        expect(command).to eq(".liberty/create_vars.rb .liberty/usr/servers/defaultServer/runtime-vars.xml && JAVA_HOME=\"$PWD/test-java-home\" .liberty/bin/server run defaultServer")
+          expect(command).to eq(".liberty/create_vars.rb .liberty/usr/servers/defaultServer/runtime-vars.xml && JAVA_HOME=\"$PWD/test-java-home\" .liberty/bin/server run defaultServer")
+        end
       end
 
       it 'should return correct execution command for the zipped-up server case' do
         LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
         .and_return(LIBERTY_VERSION)
 
-        command = Liberty.new(
-        app_dir: 'spec/fixtures/container_liberty_server',
-        java_home: 'test-java-home',
-        java_opts: '',
-        configuration: {},
-        license_ids: {}
-        ).release
+        Dir.mktmpdir do |root|
+          FileUtils.cp_r('spec/fixtures/container_liberty_server', root)
+          command = Liberty.new(
+            app_dir: File.join(root, 'container_liberty_server'),
+            java_home: 'test-java-home',
+            java_opts: '',
+            configuration: {},
+            license_ids: {}
+          ).release
 
-        expect(command).to eq(".liberty/create_vars.rb .liberty/usr/servers/myServer/runtime-vars.xml && JAVA_HOME=\"$PWD/test-java-home\" .liberty/bin/server run myServer")
+          expect(command).to eq(".liberty/create_vars.rb .liberty/usr/servers/myServer/runtime-vars.xml && JAVA_HOME=\"$PWD/test-java-home\" .liberty/bin/server run myServer")
+        end
       end
 
       it 'should return correct execution command for single-server case' do
         LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
         .and_return(LIBERTY_VERSION)
 
-        command = Liberty.new(
-        app_dir: 'spec/fixtures/container_liberty_single_server',
-        java_home: 'test-java-home',
-        java_opts: '',
-        configuration: {},
-        license_ids: {}
-        ).release
+        Dir.mktmpdir do |root|
+          FileUtils.cp_r('spec/fixtures/container_liberty_single_server', root)
+          command = Liberty.new(
+            app_dir: File.join(root, 'container_liberty_single_server'),
+            java_home: 'test-java-home',
+            java_opts: '',
+            configuration: {},
+            license_ids: {}
+          ).release
 
-        expect(command).to eq(".liberty/create_vars.rb .liberty/usr/servers/defaultServer/runtime-vars.xml && JAVA_HOME=\"$PWD/test-java-home\" .liberty/bin/server run defaultServer")
+          expect(command).to eq(".liberty/create_vars.rb .liberty/usr/servers/defaultServer/runtime-vars.xml && JAVA_HOME=\"$PWD/test-java-home\" .liberty/bin/server run defaultServer")
+        end
       end
 
       it 'should throw an error when there are multiple servers to deploy' do

--- a/spec/liberty_buildpack/diagnostics/logger_factory_spec.rb
+++ b/spec/liberty_buildpack/diagnostics/logger_factory_spec.rb
@@ -27,6 +27,10 @@ module LibertyBuildpack::Diagnostics
       $stderr = StringIO.new
     end
 
+    after do
+      $stderr = STDERR
+    end
+
     it 'should create a logger' do
       Dir.mktmpdir do |app_dir|
         logger = new_logger app_dir

--- a/spec/liberty_buildpack/framework/spring_auto_reconfiguration_spec.rb
+++ b/spec/liberty_buildpack/framework/spring_auto_reconfiguration_spec.rb
@@ -33,6 +33,11 @@ module LibertyBuildpack::Framework
       $stderr = StringIO.new
     end
 
+    after do
+      $stdout = STDOUT
+      $stderr = STDERR
+    end
+
     it 'should detect with Spring JAR in WEB-INF' do
       LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item).and_return(SPRING_AUTO_RECONFIGURATION_DETAILS)
 

--- a/spec/liberty_buildpack/jre/ibmjdk_spec.rb
+++ b/spec/liberty_buildpack/jre/ibmjdk_spec.rb
@@ -37,6 +37,11 @@ module LibertyBuildpack::Jre
       application_cache.stub(:get).and_yield(File.open('spec/fixtures/license.html'))
     end
 
+    after do
+      $stdout = STDOUT
+      $stderr = STDERR
+    end
+
     it 'should detect with id of ibmjdk-<version>' do
       Dir.mktmpdir do |root|
         LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item).and_return(DETAILS_PRE_8)

--- a/spec/liberty_buildpack/jre/openjdk_spec.rb
+++ b/spec/liberty_buildpack/jre/openjdk_spec.rb
@@ -33,6 +33,11 @@ module LibertyBuildpack::Jre
       $stderr = StringIO.new
     end
 
+    after do
+      $stdout = STDOUT
+      $stderr = STDERR
+    end
+
     it 'should detect with id of openjdk-<version>' do
       Dir.mktmpdir do |root|
         LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item).and_return(OPENJDK_DETAILS_PRE_8)


### PR DESCRIPTION
1. Reset $stderr and $stdout to their proper output stream in 'after' method if they were altered in the 'before' method to fix intermittent test error caused by a logger attempting to use previously closed $stderr.
2. Use temporary location for 'release' tests to avoid contaminating workspace when tests are run locally.
