### PR TITLE
Exclude .git, spec, and coverage reports from package

### DIFF
--- a/.package-exclude
+++ b/.package-exclude
@@ -1,0 +1,4 @@
+.*
+coverage/*
+spec/*
+Rakefile

--- a/Rakefile
+++ b/Rakefile
@@ -93,7 +93,7 @@ task :package, [:zipfile, :hosts] do |t, args|
     system("find #{dest} -type f -exec chmod a+r {} \\;")
     system("find #{dest} -type d -exec chmod a+rx {} \\;")
     system("chmod a+rx #{dest}/bin/*")
-    system("cd #{dest} && zip -r #{zipfile} .")
+    system("cd #{dest} && zip -r #{zipfile} -x@.package-exclude .")
   end
 end
 


### PR DESCRIPTION
There's no need for a packaged admin buildpack to contain all of the test artifacts, coverage reports, or git repository so exclude them from the zip when it's created.
