### PR TITLE
Copy JRE before installation

### DIFF
--- a/spec/fixtures/stub-ibm-java.bin
+++ b/spec/fixtures/stub-ibm-java.bin
@@ -1,6 +1,5 @@
-rm -rf /tmp/jre_temp
-mkdir /tmp/jre_temp
-mkdir /tmp/jre_temp/jre_dir
-mkdir /tmp/jre_temp/jre_dir/jre
-mkdir /tmp/jre_temp/jre_dir/jre/bin
-echo "java" > /tmp/jre_temp/jre_dir/jre/bin/java
+# Emulate broken JRE installer behaviour of unpacking in to current directory
+BASEDIR=$(dirname $0)
+rm -rf $BASEDIR/jre_dir
+mkdir -p $BASEDIR/jre_dir/jre/bin
+echo "java" > $BASEDIR/jre_dir/jre/bin/java

--- a/spec/liberty_buildpack/jre/ibmjdk_spec.rb
+++ b/spec/liberty_buildpack/jre/ibmjdk_spec.rb
@@ -62,7 +62,6 @@ module LibertyBuildpack::Jre
       Dir.mktmpdir do |root|
         LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item).and_return(DETAILS_PRE_8)
         LibertyBuildpack::Util::ApplicationCache.stub(:new).and_return(application_cache)
-        LibertyBuildpack::Jre::IBMJdk.stub(:cache_dir).and_return('/tmp/jre_temp')
         application_cache.stub(:get).with('test-uri').and_yield(File.open('spec/fixtures/stub-ibm-java.bin'))
 
         IBMJdk.new(


### PR DESCRIPTION
The JRE installer currently ignores the USER_INSTALL_DIR during the silent installation causing it to install in to the directory containing the .bin. This doesn't work when the .bin is part of the admin cache as this is read-only. This change copies the .bin to a temporary directory before installation. Note that it also does this in the case where the file is found in the application cache as I don't like the idea of unpacking the JRE in the cache directory.
