### PR TITLE
Update docs with new admin buildpack ZIP name

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,10 +7,10 @@ As a Cloud Foundry administrator, you can install the Liberty Buildpack as an `a
 1. In the top-level directory of the cloned repository, run the Rake `package` task:
 
    ```bash
-   rake package
+   bundle exec rake package
    ```
 
-   This task pulls down the Liberty and IBM JRE binaries and packages them with the Buildpack code in a .zip file in the parent directory. The name of the file matches the name of the repository directory.  If you are using the default name for the repository direcory, the file is named ibm-websphere-liberty-buildpack.zip.
+   This task pulls down the Liberty and IBM JRE binaries and packages them with the Buildpack code in a .zip file in the parent directory. The name of the file consists of the name of the repository directory appended with the shortened identifier of the latest commit. If you are using the default name for the repository direcory, the file name is of the form ibm-websphere-liberty-buildpack-480d2de.zip where 480d2de would be replaced by the latest commit identifier.
 
    If you are licensed to deploy the buildpack into your environment, you can create a `config/licenses.yml` file that contains the accepted license numbers prior to packaging:
 
@@ -26,15 +26,15 @@ As a Cloud Foundry administrator, you can install the Liberty Buildpack as an `a
 Install the admin Buildpack using the `cf` client as follows:
 
 ```bash
-cf create-buildpack ibm-websphere-liberty-buildpack ibm-websphere-liberty-buildpack.zip 1
+cf create-buildpack ibm-websphere-liberty-buildpack ibm-websphere-liberty-buildpack-480d2de.zip 1
 ```
 
 In this command:
 
 * `ibm-websphere-liberty-buildpack` is the name that will be given to the admin buildpack
 
-* `ibm-websphere-liberty-buildpack.zip` is the path to the .zip file that is created by the Rake task
+* `ibm-websphere-liberty-buildpack-480d2de.zip` is the path to the .zip file that is created by the Rake task
 
 * `1` is the priority given to the admin Buildpack. The lower the number the higher the priority. See the Cloud Foundry documentation for further details.
 
-Result: Users of the Cloud Foundry environment using the Liberty Buildpack do not need to specify the `-b` option in order to use the buildpack directly from GitHub. They must, however, still provide the license information in the manifest as described above.
+Result: Users of the Cloud Foundry environment using the Liberty Buildpack do not need to specify the `-b` option in order to use the buildpack directly from GitHub. They must, however, still provide the license information in the manifest unless a `config/licenses.yml` file has been provided as described above.


### PR DESCRIPTION
Update installation.md to reflect the inclusion of the commit ID in the new default ZIP file name for the admin buildpack.
