### PR TITLE
autoconfiguration for mysql and postgresql databases

### DIFF
--- a/lib/liberty_buildpack/container/container_utils.rb
+++ b/lib/liberty_buildpack/container/container_utils.rb
@@ -57,6 +57,24 @@ module LibertyBuildpack::Container
       libs
     end
 
+    # Unpacks the given zip file to the specified directory. It uses the +unzip+ or +jar+ command depending
+    # of the runtime environment.
+    #
+    # @param [String] file - the zip file to unpack
+    # @param [String] dir - the directory to unpack the zip contents into.
+    # @return [void]
+    def self.unzip(file, dir)
+      file = File.expand_path(file)
+      FileUtils.mkdir_p (dir)
+      Dir.chdir (dir) do
+        if File.exists? '/usr/bin/unzip'
+          system "unzip -qqo '#{file}'"
+        else
+          system "jar xf '#{file}'"
+        end
+      end
+    end
+
   end
 
 end

--- a/lib/liberty_buildpack/container/liberty.rb
+++ b/lib/liberty_buildpack/container/liberty.rb
@@ -30,6 +30,7 @@ require 'liberty_buildpack/util/application_cache'
 require 'liberty_buildpack/util/format_duration'
 require 'liberty_buildpack/util/properties'
 require 'liberty_buildpack/util/license_management'
+require 'liberty_buildpack/util/heroku'
 require 'open-uri'
 
 module LibertyBuildpack::Container
@@ -57,7 +58,7 @@ module LibertyBuildpack::Container
       @java_opts = context[:java_opts]
       @lib_directory = context[:lib_directory]
       @configuration = context[:configuration]
-      @vcap_services = context[:vcap_services]
+      @vcap_services = Heroku.heroku? ? Heroku.new.generate_vcap_services(ENV) : context[:vcap_services]
       @vcap_application = context[:vcap_application]
       @license_id = context[:license_ids]['IBM_LIBERTY_LICENSE']
       @environment = context[:environment]
@@ -173,7 +174,7 @@ module LibertyBuildpack::Container
         system(minify_script_string)
         # Update with minified version only if the generated file exists and not empty.
         if File.size? minified_zip
-          Liberty.unzip(minified_zip, root)
+          ContainerUtils.unzip(minified_zip, root)
           if File.exists? icap_extension
             extensions_dir = File.join(root, 'wlp', 'etc', 'extensions')
             system("mkdir -p #{extensions_dir} && cp #{icap_extension} #{extensions_dir}")
@@ -473,7 +474,7 @@ module LibertyBuildpack::Container
       print 'Installing archive ... '
       install_start_time = Time.now
       if uri.end_with?('.zip', 'jar')
-        Liberty.unzip(file.path, root)
+        ContainerUtils.unzip(file.path, root)
       elsif uri.end_with?('tar.gz', '.tgz')
         system "tar -zxf #{file.path} -C #{root} 2>&1"
       else
@@ -627,10 +628,10 @@ module LibertyBuildpack::Container
     end
 
     def log_directory
-      if ENV['DYNO'].nil?
-        return '../../../../../logs'
-      else
+      if Heroku.heroku?
         return '../../../../logs'
+      else
+        return '../../../../../logs'
       end
     end
 
@@ -742,7 +743,7 @@ module LibertyBuildpack::Container
       apps.each do |app|
         if File.file? app
           temp_directory = "#{app}.tmp"
-          Liberty.unzip(app, temp_directory)
+          ContainerUtils.unzip(app, temp_directory)
           File.delete(app)
           File.rename(temp_directory, app)
         end
@@ -752,7 +753,7 @@ module LibertyBuildpack::Container
     def self.splat_expand(apps)
       apps.each do |app|
         if File.file? app
-          Liberty.unzip(app, './app')
+          ContainerUtils.unzip(app, './app')
           FileUtils.rm_rf("#{app}")
         end
       end
@@ -764,18 +765,6 @@ module LibertyBuildpack::Container
           state = false if File.file?(file)
       end
       state
-    end
-
-    def self.unzip(file, dir)
-      file = File.expand_path(file)
-      FileUtils.mkdir_p (dir)
-      Dir.chdir (dir) do
-        if File.exists? '/usr/bin/unzip'
-          system "unzip -qqo '#{file}'"
-        else
-          system "jar xf '#{file}'"
-        end
-      end
     end
 
   end

--- a/lib/liberty_buildpack/services/config/mysql.yml
+++ b/lib/liberty_buildpack/services/config/mysql.yml
@@ -1,0 +1,31 @@
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright (c) 2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Service configuration
+---
+# attributes required by all service plugins
+class_name : LibertyBuildpack::Services::MySQL
+class_file : mysql.rb
+server_xml_stanza : dataSource
+
+# plugin specific attributes
+features : ['jdbc-4.0']
+client_jars : 'mariadb-java-client*.jar|mysql-connector-java*.jar'
+
+service_filter : 'mysql|cleardb'
+
+driver:
+  version: 1.1.+
+  repository_root: "http://download.run.pivotal.io/mariadb-jdbc"

--- a/lib/liberty_buildpack/services/config/postgresql.yml
+++ b/lib/liberty_buildpack/services/config/postgresql.yml
@@ -1,0 +1,31 @@
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright (c) 2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Service configuration
+---
+# attributes required by all service plugins
+class_name : LibertyBuildpack::Services::PostgreSQL
+class_file : postgresql.rb
+server_xml_stanza : dataSource
+
+# plugin specific attributes
+features : ['jdbc-4.0']
+client_jars : 'postgresql-.*.jar'
+
+service_filter : 'postgresql|elephantsql'
+
+driver:
+  version: 9.3.+
+  repository_root: "http://download.run.pivotal.io/postgresql-jdbc"

--- a/lib/liberty_buildpack/services/mysql.rb
+++ b/lib/liberty_buildpack/services/mysql.rb
@@ -1,0 +1,73 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'rexml/document'
+require 'liberty_buildpack/services/client_jar_utils'
+require 'liberty_buildpack/services/relational_db'
+
+module LibertyBuildpack::Services
+
+  #------------------------------------------------------------------------------------
+  # The MySQL class is the class for MySQL relational database resources.
+  #------------------------------------------------------------------------------------
+  class MySQL < RelationalDatabasePlugin
+
+    #------------------------------------------------------------------------------------
+    # Initialize
+    #
+    # @param type - the vcap_services type
+    # @param config - a hash containing the configuration data from the yml file.
+    #------------------------------------------------------------------------------------
+    def initialize(type, config)
+      super(type, config)
+      @config_type = 'mysql'
+      @properties_type = 'properties'
+    end
+
+    #------------------------------------------------------------------------------------
+    # Method to create a jdbc driver.
+    # This method will also create the library associated with the jdbc driver.
+    #
+    # @param doc - the root element of the REXML::Document for server.xml
+    # @param lib_dir - the directory where client driver jars are located
+    # @raise if an internal inconsistency was found.
+    #------------------------------------------------------------------------------------
+    def create_jdbcdriver(doc, jdbc_driver_id, lib_id, fileset_id, lib_dir)
+      # We assume a consistent server.xml. If the datasource did not exist, then this must be a pure "push app" use case. If it is a "push server.xml"
+      # case, then failure to find the datasource indicates server.xml is not consistent.
+      # TODO: surprisingly, the following will find the driver even if it is imbedded in another datasource.
+      # We could probably use XPATH /server/jdbcDriver to limit the search to global.
+      drivers = doc.elements.to_a("//jdbcDriver[@id='#{jdbc_driver_id}']")
+      # if we find an existing jdbc driver, then one of two things has occurred
+      # 1) case of pushing server.xml, but datasource not found (user error)
+      # 2) case of pushing a web app and multiple instances of a given resource type (db2) were bound. The JDBC driver was already created when
+      #    we created the datasource for a previously processed instance. All instances of a resource type share the same JDBCDriver and library.
+      if drivers.empty?
+        # Not found, create it. The JDBC Driver is created as a global element and not nested underneath the datasource.
+        # puts "jdbcDriver #{jdbc_driver_id} not found, creating it"
+        # create the jdbcDriver
+        driver = REXML::Element.new('jdbcDriver', doc.root)
+        driver.add_attribute('id', jdbc_driver_id)
+        driver.add_attribute('javax.sql.XADataSource', 'org.mariadb.jdbc.MySQLDataSource')
+        driver.add_attribute('javax.sql.ConnectionPoolDataSource', 'org.mariadb.jdbc.MySQLDataSource')
+        driver.add_attribute('libraryRef', lib_id)
+        # create the shared library. It should not exist.
+        ClientJarUtils.create_global_library(doc, lib_id, fileset_id, lib_dir, @client_jars_string)
+      end
+    end
+
+  end
+end

--- a/lib/liberty_buildpack/services/postgresql.rb
+++ b/lib/liberty_buildpack/services/postgresql.rb
@@ -1,0 +1,73 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'rexml/document'
+require 'liberty_buildpack/services/client_jar_utils'
+require 'liberty_buildpack/services/relational_db'
+
+module LibertyBuildpack::Services
+
+  #------------------------------------------------------------------------------------
+  # The PostgreSQL class is the class for PostgreSQL relational database resources.
+  #------------------------------------------------------------------------------------
+  class PostgreSQL < RelationalDatabasePlugin
+
+    #------------------------------------------------------------------------------------
+    # Initialize
+    #
+    # @param type - the vcap_services type
+    # @param config - a hash containing the configuration data from the yml file.
+    #------------------------------------------------------------------------------------
+    def initialize(type, config)
+      super(type, config)
+      @config_type = 'postgresql'
+      @properties_type = 'properties'
+    end
+
+    #------------------------------------------------------------------------------------
+    # Method to create a jdbc driver.
+    # This method will also create the library associated with the jdbc driver.
+    #
+    # @param doc - the root element of the REXML::Document for server.xml
+    # @param lib_dir - the directory where client driver jars are located
+    # @raise if an internal inconsistency was found.
+    #------------------------------------------------------------------------------------
+    def create_jdbcdriver(doc, jdbc_driver_id, lib_id, fileset_id, lib_dir)
+      # We assume a consistent server.xml. If the datasource did not exist, then this must be a pure "push app" use case. If it is a "push server.xml"
+      # case, then failure to find the datasource indicates server.xml is not consistent.
+      # TODO: surprisingly, the following will find the driver even if it is imbedded in another datasource.
+      # We could probably use XPATH /server/jdbcDriver to limit the search to global.
+      drivers = doc.elements.to_a("//jdbcDriver[@id='#{jdbc_driver_id}']")
+      # if we find an existing jdbc driver, then one of two things has occurred
+      # 1) case of pushing server.xml, but datasource not found (user error)
+      # 2) case of pushing a web app and multiple instances of a given resource type (db2) were bound. The JDBC driver was already created when
+      #    we created the datasource for a previously processed instance. All instances of a resource type share the same JDBCDriver and library.
+      if drivers.empty?
+        # Not found, create it. The JDBC Driver is created as a global element and not nested underneath the datasource.
+        # puts "jdbcDriver #{jdbc_driver_id} not found, creating it"
+        # create the jdbcDriver
+        driver = REXML::Element.new('jdbcDriver', doc.root)
+        driver.add_attribute('id', jdbc_driver_id)
+        driver.add_attribute('javax.sql.XADataSource', 'org.postgresql.xa.PGXADataSource')
+        driver.add_attribute('javax.sql.ConnectionPoolDataSource', 'org.postgresql.ds.PGConnectionPoolDataSource')
+        driver.add_attribute('libraryRef', lib_id)
+        # create the shared library. It should not exist.
+        ClientJarUtils.create_global_library(doc, lib_id, fileset_id, lib_dir, @client_jars_string)
+      end
+    end
+
+  end
+end

--- a/lib/liberty_buildpack/services/relational_db.rb
+++ b/lib/liberty_buildpack/services/relational_db.rb
@@ -1,0 +1,387 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'rexml/document'
+require 'liberty_buildpack/diagnostics/logger_factory'
+require 'liberty_buildpack/services/client_jar_utils'
+require 'liberty_buildpack/services/utils'
+require 'liberty_buildpack/repository/configured_item'
+
+module LibertyBuildpack::Services
+
+  #------------------------------------------------------------------------------------
+  # Base class for relational database resources.
+  #------------------------------------------------------------------------------------
+  class RelationalDatabasePlugin
+
+    #------------------------------------------------------------------------------------
+    # Initialize
+    #
+    # @param type - the vcap_services type
+    # @param config - a hash containing the configuration data from the yml file.
+    #------------------------------------------------------------------------------------
+    def initialize(type, config)
+      @logger = LibertyBuildpack::Diagnostics::LoggerFactory.get_logger
+      @type = type
+      @config = config
+      @features = @config['features']
+      @reg_ex = Regexp.new(@config['client_jars'])
+      @logger.debug("init type #{@type}, regex #{@reg_ex}")
+    end
+
+    #-----------------------------------------------------------------------------------------
+    # parse the vcap services and create cloud properties
+    #
+    # @param element - the root element of the REXML document for runtime-vars.xml
+    # @param instance - the hash containing the vcap_services data for this instance
+    #------------------------------------------------------------------------------------------
+    def parse_vcap_services(element, instance)
+      properties = Utils.parse_compliant_vcap_service(element, instance)
+      @service_name = properties['service_name']
+      # extract the db_name, host, port, user and password from the properties. Since we are using cloud variables for substitution into server.xml,
+      # this means we're actually using the keys in the props, not the values. We could use the values for direct substitution.
+      conn_prefix = "cloud.services.#{@service_name}.connection."
+
+      # uri is the only property portable between Pivotal, BlueMix, and Heroku
+      conn_uri = properties["#{conn_prefix}uri"]
+      if conn_uri.nil?
+        raise "Resource #{@service_name} does not contain a #{conn_prefix}uri property"
+      end
+      uri = URI.parse(conn_uri)
+
+      @db_name = get_cloud_property(properties, element, "#{conn_prefix}name", uri.path[1..-1])
+      @host = get_cloud_property(properties, element, "#{conn_prefix}host", uri.host)
+      @port = get_cloud_property(properties, element, "#{conn_prefix}port", uri.port)
+      @user = get_cloud_property(properties, element, "#{conn_prefix}user", uri.user)
+      @password =  get_cloud_property(properties, element, "#{conn_prefix}password", uri.password)
+
+      # ensure all the cloud properties are always set
+      get_cloud_property(properties, element, "#{conn_prefix}hostname", uri.host)
+      get_cloud_property(properties, element, "#{conn_prefix}username", uri.user)
+
+      # default JNDI name for DB is jdbc/service_name
+      @jndi_name = "jdbc/#{@service_name}"
+      # create standard configuration ids.
+      @datasource_id = "#{@config_type}-#{@service_name}"
+      @properties_id = "#{@config_type}-#{@service_name}-props"
+      @jdbc_driver_id = "#{@config_type}-driver"
+      @lib_id = "#{@config_type}-library"
+      @fileset_id = "#{@config_type}-fileset"
+    end
+
+    #-----------------------------------------------------------------------------------
+    # return true if this service requires Liberty extensions to be installed
+    #-----------------------------------------------------------------------------------
+    def requires_liberty_extensions?
+      false
+    end
+
+    #---------------------------------------------
+    # Get the list of Liberty features required by this service
+    #
+    # @param [Set] features - the Set to add the required features to
+    #---------------------------------------------
+    def get_required_features(features)
+      features.merge(@features) unless @features.nil?
+    end
+
+    #----------------------------------------------------------------------------------------
+    # Use the configured client_jars regular expression to determine which client jars need to be downloaded for this service to function properly
+    #
+    # @param existing - an array containing the file names of user-provided jars. If the user has provided the jar, no need to download.
+    # @param urls - an array containing the available download urls for client jars
+    # return - a non-null array of urls. Will be empty if nothing needs to be downloaded.
+    #-----------------------------------------------------------------------------------------
+    def get_urls_for_client_jars(existing, urls)
+      # search the existing jars, if found nothing to do
+      if ClientJarUtils.jar_installed?(existing, @reg_ex) == true
+        @logger.debug("user supplied client jars for #{@type}")
+        return []
+      end
+      repository = @config['driver']
+      if repository.nil?
+        @logger.debug("no repository supplied jars for #{@type}")
+        return []
+      end
+      version, driver_uri = LibertyBuildpack::Repository::ConfiguredItem.find_item(repository)
+      @logger.debug("driver version: #{version}, url: #{driver_uri}")
+      [driver_uri]
+    end
+
+    #-------------------------------------------
+    # Get required components (prereq zips and esas) from services
+    #
+    # @param uris - the hash containing the <key, uri> information from the repository
+    # @param components - the non-null RequiredComponents to update.
+    #---------------------------------------------
+    def get_required_esas(uris, components)
+      false
+    end
+
+    #------------------------------------------------------------------------------------
+    # Method to create a datasource stanza (and all related sub-artifacts such as the JDBCDriver) in server.xml.
+    #
+    # @param doc - the root element of the REXML::Document for server.xml
+    # @param server_dir - the server directory which is the location for bootstrap.properties and jvm.options
+    # @param driver_dir - the symbolic name of the directory where client jars are installed
+    # @param available_jars - an array containing the names of all installed client driver jars.
+    # @raise if a problem was discovered (incoherent or inconsistent existing configuration, for example)
+    #------------------------------------------------------------------------------------
+    def create(doc, server_dir, driver_dir, available_jars)
+      # handle client driver jars
+      @driver_dir = driver_dir
+      @client_jars_string = ClientJarUtils.client_jars_string(ClientJarUtils.get_jar_names(available_jars, @reg_ex))
+      @logger.debug("client jars string #{@client_jars_string}")
+      create_datasource(doc, @driver_dir)
+    end
+
+    #------------------------------------------------------------------------------------
+    # Method to create/update a datasource stanza (and all related sub-artifacts such as the JDBCDriver) in server.xml.
+    #
+    # @param doc - the root element of the REXML::Document for server.xml
+    # @param server_dir - the server directory which is the location for bootstrap.properties and jvm.options
+    # @param driver_dir - the symbolic name of the directory where client jars are installed
+    # @param available_jars - an array containing the names of all installed client driver jars.
+    # @param number_instances - the number of service instances that update the same service-specific server.xml stanzas
+    # @raise if a problem was discovered (incoherent or inconsistent existing configuration, for example)
+    #------------------------------------------------------------------------------------
+    def update(doc, server_dir, driver_dir, available_jars, number_instances)
+      # handle client driver jars
+      @driver_dir = driver_dir
+      @client_jars_string = ClientJarUtils.client_jars_string(ClientJarUtils.get_jar_names(available_jars, @reg_ex))
+      @logger.debug("client jars string #{@client_jars_string}")
+      # Find the datasource config for this service instance.
+      datasources = find_datasource(doc, number_instances)
+      if datasources.empty?
+        @logger.debug("datasource #{@datasource_id} not found, creating it")
+        create_datasource(doc, @driver_dir)
+      else
+        # Find the jdbc driver. Use the jdbc driver to find the shared library.
+        jdbc_driver = find_jdbc_driver(doc, datasources)
+        library = find_shared_library(doc, jdbc_driver)
+        ClientJarUtils.update_library(doc, @service_name, library, @fileset_id, @driver_dir, @client_jars_string)
+
+        # Do not update datasource attributes. Specifically, do not update the jndi name. We do need to update the properties attributes though.
+        # find the instance that contains the properties. Liberty only allows one instance of properties.
+        properties_element = find_datasource_properties(datasources)
+        update_datasource_attribute(properties_element, 'databaseName', @db_name)
+        update_datasource_attribute(properties_element, 'user', @user)
+        update_datasource_attribute(properties_element, 'password', @password)
+        update_datasource_attribute(properties_element, 'serverName', @host)
+        update_datasource_attribute(properties_element, 'portNumber', @port)
+        Utils.add_features(doc, @features)
+      end
+    end
+
+    private
+
+    def get_cloud_property(properties, element, name, value)
+      variable = element.root.elements.to_a("//variable[@name='#{name}']")
+      if variable.empty?
+        if value.nil?
+          return nil
+        else
+          new_element = REXML::Element.new('variable', element)
+          new_element.add_attribute('name', name)
+          new_element.add_attribute('value', value)
+        end
+      end
+      "${#{name}}"
+    end
+
+    #------------------------------------------------------------------------------------
+    # Method to find the single properties instance for a given datasource.
+    #
+    # @param datasources - an array containing all datasource stanzas with a given id.
+    # return the properties Element
+    #------------------------------------------------------------------------------------
+    def find_datasource_properties(datasources)
+      # Get the expected properties based on type.
+      expected = @properties_type
+      datasources.each do |datasource|
+        datasource.elements.each do |element|
+          # if name matches exactly, then we are done.
+          return element if element.name == expected
+          if element.name.start_with? 'properties'
+            # found the properties element, but it's the wrong type. Update the name to expected type
+            @logger.debug("found properties, but wrong type. Found #{element.name} expected #{expected}")
+            element.name = expected
+            return element
+          end
+        end
+      end
+      # if we got here, then we didn't find any properties. Create a properties instance of the expected type.
+      props = REXML::Element.new(expected, datasources[0])
+      props
+    end
+
+    #------------------------------------------------------------------------------------
+    # A private worker method for the create_or_update_datasource method.
+    # This method will only be called when a datasource does not exist.
+    #
+    # @param prop - the properties Element for the datasource
+    # @param attrName - the String name of attribute to update
+    # @param value - the String value of the attribute
+    #------------------------------------------------------------------------------------
+    def update_datasource_attribute(prop, attrName, value)
+      if prop.attribute(attrName).nil? || prop.attribute(attrName).value != value
+        # puts "datasource #{attrName} being updated"
+        prop.delete_attribute(attrName)
+        prop.add_attribute(attrName, value)
+        return
+      end
+    end
+
+    #------------------------------------------------------------------------------------
+    # A private worker method for the create_or_update_datasource method.
+    # This method will only be called when a datasource does not exist.
+    #
+    # @param doc - the root element of the REXML::Document for server.xml
+    # @param lib_dir - the String name of directory where client driver jars are located
+    # @raise if an inconsistency is found (shared library already exists but JDBC driver does not)
+    #------------------------------------------------------------------------------------
+    def create_datasource(doc, lib_dir)
+      # create the datasource and set the standard set of attributes.
+      ds = REXML::Element.new('dataSource', doc.root)
+      ds.add_attribute('id', @datasource_id)
+      ds.add_attribute('jdbcDriverRef', @jdbc_driver_id)
+      ds.add_attribute('jndiName', @jndi_name)
+      ds.add_attribute('transactional', 'true')
+      # add properties element and standard set of attributes.
+      props = REXML::Element.new(@properties_type, ds)
+      props.add_attribute('id', @properties_id)
+      props.add_attribute('databaseName', @db_name)
+      props.add_attribute('user', @user)
+      props.add_attribute('password', @password)
+      props.add_attribute('portNumber', @port)
+      props.add_attribute('serverName', @host)
+      # create the JDBC driver. The JDBC driver will create the shared library.
+      create_jdbcdriver(doc, @jdbc_driver_id, @lib_id, @fileset_id, lib_dir)
+      Utils.add_features(doc, @features)
+    end
+
+    #------------------------------------------------------------------------------------
+    # Method to create a jdbc driver.
+    # This method will also create the library associated with the jdbc driver.
+    #
+    # @param doc - the root element of the REXML::Document for server.xml
+    # @param lib_dir - the directory where client driver jars are located
+    # @raise if an internal inconsistency was found.
+    #------------------------------------------------------------------------------------
+    def create_jdbcdriver(doc, jdbc_driver_id, lib_id, fileset_id, lib_dir)
+      # We assume a consistent server.xml. If the datasource did not exist, then this must be a pure "push app" use case. If it is a "push server.xml"
+      # case, then failure to find the datasource indicates server.xml is not consistent.
+      # TODO: surprisingly, the following will find the driver even if it is imbedded in another datasource.
+      # We could probably use XPATH /server/jdbcDriver to limit the search to global.
+      drivers = doc.elements.to_a("//jdbcDriver[@id='#{jdbc_driver_id}']")
+      # if we find an existing jdbc driver, then one of two things has occurred
+      # 1) case of pushing server.xml, but datasource not found (user error)
+      # 2) case of pushing a web app and multiple instances of a given resource type (db2) were bound. The JDBC driver was already created when
+      #    we created the datasource for a previously processed instance. All instances of a resource type share the same JDBCDriver and library.
+      if drivers.empty?
+        # Not found, create it. The JDBC Driver is created as a global element and not nested underneath the datasource.
+        # puts "jdbcDriver #{jdbc_driver_id} not found, creating it"
+        # create the jdbcDriver
+        driver = REXML::Element.new('jdbcDriver', doc.root)
+        driver.add_attribute('id', jdbc_driver_id)
+        driver.add_attribute('libraryRef', lib_id)
+        # create the shared library. It should not exist.
+        ClientJarUtils.create_global_library(doc, lib_id, fileset_id, lib_dir, @client_jars_string)
+      end
+    end
+
+    #-----------------------------------------------------------------
+    # Return the array of dataSource elements for this service. The returned array will either be empty or will contain the
+    # datasource elements for a single datasource. (the configuraton for the single datasource may be partitioned over
+    # multiple physical elements.
+    #
+    # @param doc - the root element of the REXML::Document for server.xml
+    # @param number_instances - the number of bound service instances.
+    #-----------------------------------------------------------------
+    def find_datasource(doc, number_instances)
+      # When only one service instance is bound, then we do not require matching config ids. When multiple service instances are bound, we do.
+      if number_instances == 1
+        # tolerate degenerate condition of multiple datasources configured but only 1 is bound.
+        datasources = doc.elements.to_a("//dataSource[@id='#{@datasource_id}']")
+        datasources = doc.elements.to_a('//dataSource') if datasources.empty?
+      else
+        datasources = doc.elements.to_a("//dataSource[@id='#{@datasource_id}']")
+      end
+      return datasources if datasources.empty?
+      raise "The datasource configuration for service #{@service_name} is inconsistent" unless Utils.is_logical_singleton?(datasources)
+      datasources
+    end
+
+    #------------------------------------------------------------------------------------
+    # Return an array that contains the single JBDC Element for the specified datasource. The one logical datasource
+    # may be partitioned over multiple physical Elements.
+    #
+    # @param doc - the root element of the REXML::Document for server.xml
+    # @param datasources - a non-null, non-empty array containing all elements for a given datasource.
+    # return the array containing logical Element for the JDBC driver. It may be partitioned over multiple instances.
+    # @raise if jdbc driver does not exist or config is incoherent.
+    #------------------------------------------------------------------------------------
+    def find_jdbc_driver(doc, datasources)
+      by_reference = []
+      by_containment = []
+      datasources.each do |datasource|
+        # first check for a jdbcDriverRef attribute. jdbcDriverRefs that point to non-existent jdbcDrivers will be filtered out by the following
+        jdbc_attribute = datasource.attribute('jdbcDriverRef').value unless datasource.attribute('jdbcDriverRef').nil?
+        unless jdbc_attribute.nil?
+          drivers = doc.elements.to_a("//jdbcDriver[@id='#{jdbc_attribute}']")
+          drivers.each { |driver| by_reference.push(driver) }
+        end
+        # next check for jdbcDriver elements
+        jdbc_elements = datasource.get_elements('jdbcDriver')
+        jdbc_elements.each { |element| by_containment.push(element) }
+      end
+      # if jdbc drivers have been configured both by containment and by reference, liberty will fail without logging helpful messages.
+      raise "Found JDBC driver by-reference and by-containment for #{@service_name}" unless by_reference.empty? || by_containment.empty?
+      raise "There is no configured JDBC driver for #{@service_name}" if by_reference.empty? && by_containment.empty?
+      jdbc_driver = by_reference.empty? ? by_containment : by_reference
+      raise "JDBC Driver configuration for #{@service_name} is inconsistent" unless Utils.is_logical_singleton?(jdbc_driver)
+      jdbc_driver
+    end
+
+    #------------------------------------------------------------------------------------
+    # Method that finds and returns the library Element for an existing JDBC Driver. The returned Element may be a root element in the
+    # document (a shareable library) or it may be a private library contained directly in the JDBC driver.
+    #
+    # @param doc - the root element of the REXML::Document for server.xml
+    # @param jdbc_driver - the array of Elements over which the JDBC driver configuration is distributed.
+    # return the Element for the library
+    #------------------------------------------------------------------------------------
+    def find_shared_library(doc, jdbc_driver)
+      by_reference = []
+      by_containment = []
+      jdbc_driver.each do |driver|
+        # by reference - check for libraryRef
+        lib_attribute = driver.attribute('libraryRef').value unless driver.attribute('libraryRef').nil?
+        unless lib_attribute.nil?
+          libs = doc.elements.to_a("//library[@id='#{lib_attribute}']")
+          libs.each { |lib| by_reference.push(lib) }
+        end
+        # next check for contained library elements
+        lib_elements = driver.get_elements('library')
+        lib_elements.each { |element| by_containment.push(element) }
+      end
+      raise "JDBC library for #{@service_name} is configured incorrectly. It is configured both by-reference and by-containment" unless by_reference.empty? || by_containment.empty?
+      raise "There is no configured JDBC library for #{@service_name}" if by_reference.empty? && by_containment.empty?
+      library = by_reference.empty? ? by_containment : by_reference
+      library
+    end
+  end
+end

--- a/lib/liberty_buildpack/util/heroku.rb
+++ b/lib/liberty_buildpack/util/heroku.rb
@@ -1,0 +1,119 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright (c) 2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'liberty_buildpack/util'
+
+module LibertyBuildpack::Util
+
+  # Heroku utilities.
+  class Heroku
+
+    # Detects Heroku environment.
+    #
+    # @return [Boolean] +true+ if running on Heroku. +False+ otherwise.
+    def self.heroku?
+      ENV['DYNO'].nil? ? false : true
+    end
+
+    # Generates VCAP_SERVICES style map from a map that represents the environment variables
+    # as set on Heroku. Each bound service on Heroku sets one or more environment variables that
+    # specifies the location (in the form of a URL) of the service.
+    #
+    # @param [Hash] env - the map with environment variables
+    # @return [Hash] VCAP_SERVICES style map
+    def generate_vcap_services(env)
+      vcap_services = {}
+      service_name_map = parse_service_name_map(env)
+      env.each do | key, value |
+        if key.end_with?(URL_SUFFIX)
+          begin
+            uri = URI.parse(value)
+          rescue URI::InvalidURIError
+            next
+          end
+
+          if key.start_with?(POSTGRESQL_PREFIX)
+            type, service = handle_postgresql(key, uri, service_name_map)
+          elsif key.start_with?(CLEARDB_PREFIX)
+            type, service = handle_cleardb(key, uri, service_name_map)
+          else
+            type = key
+            service = {}
+            service['name'] = service_name_map[key] || generate_name(key)
+            service['credentials'] = create_default_credentials(uri)
+          end
+
+          vcap_services[type] = [service]
+        end
+      end
+      vcap_services
+    end
+
+    private
+
+    URL_SUFFIX = '_URL'.freeze
+    POSTGRESQL_PREFIX = 'HEROKU_POSTGRESQL_'.freeze
+    CLEARDB_PREFIX = 'CLEARDB_DATABASE_'.freeze
+
+    def handle_postgresql(key, uri, service_name_map)
+      type = 'postgresql'
+      service = {}
+      service['name'] = service_name_map[key] || type + '.' + key[POSTGRESQL_PREFIX.size..-URL_SUFFIX.size - 1].downcase
+      service['tags'] = ['postgresql']
+      service['credentials'] = create_default_credentials(uri)
+      [key, service]
+    end
+
+    def handle_cleardb(key, uri, service_name_map)
+      type = 'cleardb'
+      service = {}
+      service['name'] = service_name_map[key] || type
+      service['tags'] = ['mysql']
+      service['credentials'] = create_default_credentials(uri)
+      [key, service]
+    end
+
+    def create_default_credentials(uri)
+      credentials = {}
+      credentials['host'] = credentials['hostname'] = uri.host
+      credentials['port'] = uri.port unless uri.port.nil?
+      credentials['user'] = credentials['username'] = uri.user unless uri.user.nil?
+      credentials['password'] = uri.password unless uri.password.nil?
+      credentials['name'] = uri.path[1..-1]  unless uri.path[1..-1].nil?
+      credentials['uri'] = credentials['url'] = uri.to_s
+      credentials
+    end
+
+    def generate_name(url)
+      # remove _URL at the end & downcase it
+      name = url[0..-URL_SUFFIX.size - 1].downcase
+      name
+    end
+
+    def parse_service_name_map(env)
+      name_map = env['SERVICE_NAME_MAP']
+      map = {}
+      unless name_map.nil?
+        name_map.split(';').each do | value |
+          key_value = value.split('=')
+          map[key_value[0].strip] = key_value[1].strip if key_value.size == 2
+        end
+      end
+      map
+    end
+  end
+
+end

--- a/spec/liberty_buildpack/services/mysql_spec.rb
+++ b/spec/liberty_buildpack/services/mysql_spec.rb
@@ -1,0 +1,286 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+require 'spec_helper'
+require 'liberty_buildpack/container/services_manager'
+require 'liberty_buildpack/util/heroku'
+
+module LibertyBuildpack::Services
+
+  describe 'MySQL' do
+
+    #----------------
+    # Helper method to check an xml file agains expected results.
+    #
+    # @param xml - the name of the xml file file containing the results (server.xml, runtime_vars.xml)
+    # @param - expected - the array of strings we expect to find in the xml file, in order.
+    #----------------
+    def validate_xml(server_xml, expected)
+      # Collapse XML into one long String (no cr or lf).
+      server_xml_contents_array = File.readlines(server_xml).each do |line|
+        line.strip!
+      end
+      server_xml_contents = server_xml_contents_array.join
+      # For each String in the expected array, make sure there is a corresponding entry in server.xml
+      # make sure we consume all entries in the expected array.
+      expected.each do |line|
+        expect(server_xml_contents).to include(line)
+      end
+    end
+
+    describe 'Generate configuration' do
+
+      #----------------------------------------------------------
+      # Helper methods to return constants used in checking server.xml contents
+      #----------------------------------------------------------
+      def get_ds_id
+        'mysql-myDatabase'
+      end
+
+      def get_props_id
+        'mysql-myDatabase-props'
+      end
+
+      def get_driver_id
+        'mysql-driver'
+      end
+
+      def get_lib_id
+        'mysql-library'
+      end
+
+      def get_fileset_id
+        'mysql-fileset'
+      end
+
+      def get_lib_dir
+        '${server.config.dir}/lib'
+      end
+
+      def get_jndi
+        'jdbc/myDatabase'
+      end
+
+      def get_host
+        '${cloud.services.myDatabase.connection.host}'
+      end
+
+      def get_port
+        '${cloud.services.myDatabase.connection.port}'
+      end
+
+      def get_user
+        '${cloud.services.myDatabase.connection.user}'
+      end
+
+      def get_password
+        '${cloud.services.myDatabase.connection.password}'
+      end
+
+      def get_name
+        '${cloud.services.myDatabase.connection.name}'
+      end
+
+      def check_variables(root, vcap_services)
+        expected_vars = []
+        expected_vars << '<variable name=\'cloud.services.myDatabase.connection.name\' value=\'myDb\'/>'
+        expected_vars << '<variable name=\'cloud.services.myDatabase.connection.host\' value=\'myHost.com\'/>'
+        expected_vars << '<variable name=\'cloud.services.myDatabase.connection.port\' value=\'5432\'/>'
+        expected_vars << '<variable name=\'cloud.services.myDatabase.connection.user\' value=\'myUser\'/>'
+        expected_vars << '<variable name=\'cloud.services.myDatabase.connection.password\' value=\'myPassword\'/>'
+        expected_vars << '<variable name=\'cloud.services.myDatabase.connection.uri\' value=\'mysql://myUser:myPassword@myHost.com:5432/myDb\'/>'
+
+        runtime_vars = File.join(root, 'runtime-vars.xml')
+        validate_xml(runtime_vars, expected_vars)
+      end
+
+      def check_server_xml_create(root, sm)
+        server_xml = File.join(root, 'server.xml')
+        server_xml_doc = REXML::Document.new('<server><featureManager/></server>')
+        sm.update_configuration(server_xml_doc, true, root)
+        File.open(server_xml, 'w') { |file| server_xml_doc.write(file) }
+
+        expected_config = []
+        expected_config << '<feature>jdbc-4.0</feature>'
+        t1 = "<dataSource id='#{get_ds_id}' jdbcDriverRef='#{get_driver_id}' jndiName='#{get_jndi}' transactional='true'>"
+        t2 = "<properties databaseName='#{get_name}' id='#{get_props_id}' password='#{get_password}' portNumber='#{get_port}' serverName='#{get_host}' user='#{get_user}'/>"
+        t3 = '</dataSource>'
+        expected_config << t1 + t2 + t3
+        driver_info = "javax.sql.ConnectionPoolDataSource='org.mariadb.jdbc.MySQLDataSource' javax.sql.XADataSource='org.mariadb.jdbc.MySQLDataSource'"
+        expected_config << "<jdbcDriver id='#{get_driver_id}' #{driver_info} libraryRef='#{get_lib_id}'/>"
+        expected_config << "<library id='#{get_lib_id}'><fileset dir='#{get_lib_dir}' id='#{get_fileset_id}'/></library>"
+        validate_xml(server_xml, expected_config)
+      end
+
+      def check_server_xml_update(root, sm)
+        driver_info = "javax.sql.ConnectionPoolDataSource='org.mariadb.jdbc.MySQLDataSource'"
+
+        contents = []
+        contents << '<server>'
+        contents << '<featureManager><feature>jsp-2.2</feature></featureManager>'
+        t1 = "<dataSource id='#{get_ds_id}' jdbcDriverRef='myDriver' jndiName='myJndi' transactional='true'>"
+        t2 = "<properties databaseName='noName' password='noPassword' portNumber='1111' serverName='noHost' user='noUser'/>"
+        t3 = '</dataSource>'
+        contents << t1 + t2 + t3
+        contents << "<jdbcDriver id='myDriver' #{driver_info} libraryRef='myLibrary'/>"
+        contents << "<library id='myLibrary'><fileset dir='lib' id='lib-id'/></library>"
+        contents << '</server>'
+
+        server_xml_doc = REXML::Document.new(contents.join)
+        server_xml = File.join(root, 'server.xml')
+        sm.update_configuration(server_xml_doc, false, root)
+
+        File.open(server_xml, 'w') { |file| server_xml_doc.write(file) }
+
+        # check if dataSource properties and library were updated. Other elements should not be updated.
+        expected_config = []
+        expected_config << '<feature>jsp-2.2</feature>'
+        expected_config << '<feature>jdbc-4.0</feature>'
+        t1 = "<dataSource id='#{get_ds_id}' jdbcDriverRef='myDriver' jndiName='myJndi' transactional='true'>"
+        t2 = "<properties databaseName='#{get_name}' password='#{get_password}' portNumber='#{get_port}' serverName='#{get_host}' user='#{get_user}'/>"
+        t3 = '</dataSource>'
+        expected_config << t1 + t2 + t3
+        expected_config << "<jdbcDriver id='myDriver' #{driver_info} libraryRef='myLibrary'/>"
+        expected_config << "<library id='myLibrary'><fileset dir='lib' id='lib-id'/><fileset dir='#{get_lib_dir}'/></library>"
+        validate_xml(server_xml, expected_config)
+      end
+
+      def run_test(vcap_services)
+        Dir.mktmpdir do |root|
+          sm = LibertyBuildpack::Container::ServicesManager.new(vcap_services, root, nil)
+          check_variables(root, vcap_services)
+          check_server_xml_create(root, sm)
+          check_server_xml_update(root, sm)
+        end
+      end
+
+      it 'on Bluemix (mysql)' do
+        vcap_services = {}
+        mysql = {}
+        mysql['name'] = 'myDatabase'
+        mysql['label'] = 'mysql-5.5'
+        mysql_credentials = {}
+        mysql_credentials['name'] = 'myDb'
+        mysql_credentials['host'] = 'myHost.com'
+        mysql_credentials['hostname'] = 'myHost.com'
+        mysql_credentials['port'] = '5432'
+        mysql_credentials['user'] = 'myUser'
+        mysql_credentials['username'] = 'myUser'
+        mysql_credentials['password'] = 'myPassword'
+        mysql_credentials['uri'] = 'mysql://myUser:myPassword@myHost.com:5432/myDb'
+        mysql['credentials'] = mysql_credentials
+        vcap_services['mysql-5.5'] = [mysql]
+
+        run_test(vcap_services)
+      end
+
+      it 'on Bluemix (cleardb)' do
+        vcap_services = {}
+        cleardb = {}
+        cleardb['name'] = 'myDatabase'
+        cleardb['label'] = 'cleardb'
+        cleardb_credentials = {}
+        cleardb_credentials['name'] = 'myDb'
+        cleardb_credentials['host'] = 'myHost.com'
+        cleardb_credentials['hostname'] = 'myHost.com'
+        cleardb_credentials['port'] = '5432'
+        cleardb_credentials['user'] = 'myUser'
+        cleardb_credentials['username'] = 'myUser'
+        cleardb_credentials['password'] = 'myPassword'
+        cleardb_credentials['uri'] = 'mysql://myUser:myPassword@myHost.com:5432/myDb'
+        cleardb['credentials'] = cleardb_credentials
+        vcap_services['cleardb'] = [cleardb]
+
+        run_test(vcap_services)
+      end
+
+      it 'on Pivotal' do
+        vcap_services = {}
+        cleardb = {}
+        cleardb['name'] = 'myDatabase'
+        cleardb['label'] = 'cleardb'
+        cleardb['tags'] = %w('relational', 'mysql')
+        cleardb_credentials = {}
+        cleardb_credentials['name'] = 'myDb'
+        cleardb_credentials['hostname'] = 'myHost.com'
+        cleardb_credentials['port'] = '5432'
+        cleardb_credentials['username'] = 'myUser'
+        cleardb_credentials['password'] = 'myPassword'
+        cleardb_credentials['uri'] = 'mysql://myUser:myPassword@myHost.com:5432/myDb'
+        cleardb['credentials'] = cleardb_credentials
+        vcap_services['cleardb'] = [cleardb]
+
+        run_test(vcap_services)
+      end
+
+      it 'on Heroku' do
+        env = {}
+        env['CLEARDB_DATABASE_URL'] = 'mysql://myUser:myPassword@myHost.com:5432/myDb'
+        env['SERVICE_NAME_MAP'] = 'CLEARDB_DATABASE_URL=myDatabase;foo=bar'
+        vcap_services = LibertyBuildpack::Util::Heroku.new.generate_vcap_services(env)
+
+        run_test(vcap_services)
+      end
+
+      #--------------------------------------------------------------
+      # Handle case where mysql URL does not specify an explicit port
+      #--------------------------------------------------------------
+      it 'on Heroku, no port' do
+        env = {}
+        env['CLEARDB_DATABASE_URL'] = 'mysql://myUser:myPassword@myHost.com/myDb'
+        env['SERVICE_NAME_MAP'] = 'CLEARDB_DATABASE_URL=myDatabase;foo=bar'
+        vcap_services = LibertyBuildpack::Util::Heroku.new.generate_vcap_services(env)
+
+        Dir.mktmpdir do |root|
+          runtime_vars = File.join(root, 'runtime-vars.xml')
+          sm = LibertyBuildpack::Container::ServicesManager.new(vcap_services, root, nil)
+
+          # validate runtime-var.xml updates
+          expected_vars = []
+          expected_vars << '<variable name=\'cloud.services.myDatabase.connection.name\' value=\'myDb\'/>'
+          expected_vars << '<variable name=\'cloud.services.myDatabase.connection.host\' value=\'myHost.com\'/>'
+          expected_vars << '<variable name=\'cloud.services.myDatabase.connection.user\' value=\'myUser\'/>'
+          expected_vars << '<variable name=\'cloud.services.myDatabase.connection.password\' value=\'myPassword\'/>'
+          expected_vars << '<variable name=\'cloud.services.myDatabase.connection.uri\' value=\'mysql://myUser:myPassword@myHost.com/myDb\'/>'
+          validate_xml(runtime_vars, expected_vars)
+
+          # port cloud property should not et set
+          runtime_vars_doc = File.open(runtime_vars, 'r') { |file| REXML::Document.new(file) }
+          expect(runtime_vars_doc.elements.to_a("//variable[@name='cloud.services.myDatabase.connection.port']")).to be_empty
+
+          # validate server.xml updates
+          server_xml = File.join(root, 'server.xml')
+          server_xml_doc = REXML::Document.new('<server><featureManager/></server>')
+          sm.update_configuration(server_xml_doc, true, root)
+          File.open(server_xml, 'w') { |file| server_xml_doc.write(file) }
+
+          expected_config = []
+          expected_config << '<feature>jdbc-4.0</feature>'
+          t1 = "<dataSource id='#{get_ds_id}' jdbcDriverRef='#{get_driver_id}' jndiName='#{get_jndi}' transactional='true'>"
+          t2 = "<properties databaseName='#{get_name}' id='#{get_props_id}' password='#{get_password}' serverName='#{get_host}' user='#{get_user}'/>"
+          t3 = '</dataSource>'
+          expected_config << t1 + t2 + t3
+          driver_info = "javax.sql.ConnectionPoolDataSource='org.mariadb.jdbc.MySQLDataSource' javax.sql.XADataSource='org.mariadb.jdbc.MySQLDataSource'"
+          expected_config << "<jdbcDriver id='#{get_driver_id}' #{driver_info} libraryRef='#{get_lib_id}'/>"
+          expected_config << "<library id='#{get_lib_id}'><fileset dir='#{get_lib_dir}' id='#{get_fileset_id}'/></library>"
+          validate_xml(server_xml, expected_config)
+        end
+      end
+
+    end
+  end
+
+end

--- a/spec/liberty_buildpack/services/postgresql_spec.rb
+++ b/spec/liberty_buildpack/services/postgresql_spec.rb
@@ -1,0 +1,231 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+require 'spec_helper'
+require 'liberty_buildpack/container/services_manager'
+require 'liberty_buildpack/util/heroku'
+
+module LibertyBuildpack::Services
+
+  describe 'PostgreSQL' do
+
+    #----------------
+    # Helper method to check an xml file agains expected results.
+    #
+    # @param xml - the name of the xml file file containing the results (server.xml, runtime_vars.xml)
+    # @param - expected - the array of strings we expect to find in the xml file, in order.
+    #----------------
+    def validate_xml(server_xml, expected)
+      # Collapse XML into one long String (no cr or lf).
+      server_xml_contents_array = File.readlines(server_xml).each do |line|
+        line.strip!
+      end
+      server_xml_contents = server_xml_contents_array.join
+      # For each String in the expected array, make sure there is a corresponding entry in server.xml
+      # make sure we consume all entries in the expected array.
+      expected.each do |line|
+        expect(server_xml_contents).to include(line)
+      end
+    end
+
+    describe 'Generate configuration' do
+
+      #----------------------------------------------------------
+      # Helper methods to return constants used in checking server.xml contents
+      #----------------------------------------------------------
+      def get_ds_id
+        'postgresql-myDatabase'
+      end
+
+      def get_props_id
+        'postgresql-myDatabase-props'
+      end
+
+      def get_driver_id
+        'postgresql-driver'
+      end
+
+      def get_lib_id
+        'postgresql-library'
+      end
+
+      def get_fileset_id
+        'postgresql-fileset'
+      end
+
+      def get_lib_dir
+        '${server.config.dir}/lib'
+      end
+
+      def get_jndi
+        'jdbc/myDatabase'
+      end
+
+      def get_host
+        '${cloud.services.myDatabase.connection.host}'
+      end
+
+      def get_port
+        '${cloud.services.myDatabase.connection.port}'
+      end
+
+      def get_user
+        '${cloud.services.myDatabase.connection.user}'
+      end
+
+      def get_password
+        '${cloud.services.myDatabase.connection.password}'
+      end
+
+      def get_name
+        '${cloud.services.myDatabase.connection.name}'
+      end
+
+      def check_variables(root, vcap_services)
+        expected_vars = []
+        expected_vars << '<variable name=\'cloud.services.myDatabase.connection.name\' value=\'myDb\'/>'
+        expected_vars << '<variable name=\'cloud.services.myDatabase.connection.host\' value=\'myHost.com\'/>'
+        expected_vars << '<variable name=\'cloud.services.myDatabase.connection.port\' value=\'5432\'/>'
+        expected_vars << '<variable name=\'cloud.services.myDatabase.connection.user\' value=\'myUser\'/>'
+        expected_vars << '<variable name=\'cloud.services.myDatabase.connection.password\' value=\'myPassword\'/>'
+        expected_vars << '<variable name=\'cloud.services.myDatabase.connection.uri\' value=\'postgres://myUser:myPassword@myHost.com:5432/myDb\'/>'
+
+        runtime_vars = File.join(root, 'runtime-vars.xml')
+        validate_xml(runtime_vars, expected_vars)
+      end
+
+      def check_server_xml_create(root, sm)
+        server_xml = File.join(root, 'server.xml')
+        server_xml_doc = REXML::Document.new('<server><featureManager/></server>')
+
+        sm.update_configuration(server_xml_doc, true, root)
+
+        File.open(server_xml, 'w') { |file| server_xml_doc.write(file) }
+
+        expected_config = []
+        expected_config << '<feature>jdbc-4.0</feature>'
+        t1 = "<dataSource id='#{get_ds_id}' jdbcDriverRef='#{get_driver_id}' jndiName='#{get_jndi}' transactional='true'>"
+        t2 = "<properties databaseName='#{get_name}' id='#{get_props_id}' password='#{get_password}' portNumber='#{get_port}' serverName='#{get_host}' user='#{get_user}'/>"
+        t3 = '</dataSource>'
+        expected_config << t1 + t2 + t3
+        driver_info = "javax.sql.ConnectionPoolDataSource='org.postgresql.ds.PGConnectionPoolDataSource' javax.sql.XADataSource='org.postgresql.xa.PGXADataSource'"
+        expected_config << "<jdbcDriver id='#{get_driver_id}' #{driver_info} libraryRef='#{get_lib_id}'/>"
+        expected_config << "<library id='#{get_lib_id}'><fileset dir='#{get_lib_dir}' id='#{get_fileset_id}'/></library>"
+        validate_xml(server_xml, expected_config)
+      end
+
+      def check_server_xml_update(root, sm)
+        driver_info = "javax.sql.ConnectionPoolDataSource='org.postgresql.ds.PGConnectionPoolDataSource'"
+
+        contents = []
+        contents << '<server>'
+        contents << '<featureManager><feature>jsp-2.2</feature></featureManager>'
+        t1 = "<dataSource id='#{get_ds_id}' jdbcDriverRef='myDriver' jndiName='myJndi' transactional='true'>"
+        t2 = "<properties databaseName='noName' password='noPassword' portNumber='1111' serverName='noHost' user='noUser'/>"
+        t3 = '</dataSource>'
+        contents << t1 + t2 + t3
+        contents << "<jdbcDriver id='myDriver' #{driver_info} libraryRef='myLibrary'/>"
+        contents << "<library id='myLibrary'><fileset dir='lib' id='lib-id'/></library>"
+        contents << '</server>'
+
+        server_xml_doc = REXML::Document.new(contents.join)
+        server_xml = File.join(root, 'server.xml')
+        sm.update_configuration(server_xml_doc, false, root)
+
+        File.open(server_xml, 'w') { |file| server_xml_doc.write(file) }
+
+        # check if dataSource properties and library were updated. Other elements should not be updated.
+        expected_config = []
+        expected_config << '<feature>jsp-2.2</feature>'
+        expected_config << '<feature>jdbc-4.0</feature>'
+        t1 = "<dataSource id='#{get_ds_id}' jdbcDriverRef='myDriver' jndiName='myJndi' transactional='true'>"
+        t2 = "<properties databaseName='#{get_name}' password='#{get_password}' portNumber='#{get_port}' serverName='#{get_host}' user='#{get_user}'/>"
+        t3 = '</dataSource>'
+        expected_config << t1 + t2 + t3
+        expected_config << "<jdbcDriver id='myDriver' #{driver_info} libraryRef='myLibrary'/>"
+        expected_config << "<library id='myLibrary'><fileset dir='lib' id='lib-id'/><fileset dir='#{get_lib_dir}'/></library>"
+        validate_xml(server_xml, expected_config)
+      end
+
+      def run_test(vcap_services)
+        Dir.mktmpdir do |root|
+          sm = LibertyBuildpack::Container::ServicesManager.new(vcap_services, root, nil)
+          check_variables(root, vcap_services)
+          check_server_xml_create(root, sm)
+          check_server_xml_update(root, sm)
+        end
+      end
+
+      it 'on Bluemix (postgresql)' do
+        vcap_services = {}
+        postgresql = {}
+        postgresql['name'] = 'myDatabase'
+        postgresql['label'] = 'postgresql-9.1'
+        postgresql_credentials = {}
+        postgresql_credentials['name'] = 'myDb'
+        postgresql_credentials['host'] = 'myHost.com'
+        postgresql_credentials['hostname'] = 'myHost.com'
+        postgresql_credentials['port'] = '5432'
+        postgresql_credentials['user'] = 'myUser'
+        postgresql_credentials['username'] = 'myUser'
+        postgresql_credentials['password'] = 'myPassword'
+        postgresql_credentials['uri'] = 'postgres://myUser:myPassword@myHost.com:5432/myDb'
+        postgresql['credentials'] = postgresql_credentials
+        vcap_services['postgresql-9.1'] = [postgresql]
+
+        run_test(vcap_services)
+      end
+
+      it 'on Bluemix (elephantsql)' do
+        vcap_services = {}
+        elephantsql = {}
+        elephantsql['name'] = 'myDatabase'
+        elephantsql['label'] = 'elephantsql'
+        elephantsql_credentials = {}
+        elephantsql_credentials['uri'] = 'postgres://myUser:myPassword@myHost.com:5432/myDb'
+        elephantsql['credentials'] = elephantsql_credentials
+        vcap_services['elephantsql'] = [elephantsql]
+
+        run_test(vcap_services)
+      end
+
+      it 'on Pivotal' do
+        vcap_services = {}
+        elephantsql = {}
+        elephantsql['name'] = 'myDatabase'
+        elephantsql['label'] = 'elephantsql'
+        elephantsql['tags'] = %w('relational', 'postgresql')
+        elephantsql_credentials = {}
+        elephantsql_credentials['uri'] = 'postgres://myUser:myPassword@myHost.com:5432/myDb'
+        elephantsql['credentials'] = elephantsql_credentials
+        vcap_services['elephantsql'] = [elephantsql]
+
+        run_test(vcap_services)
+      end
+
+      it 'on Heroku' do
+        env = {}
+        env['HEROKU_POSTGRESQL_RED_URL'] = 'postgres://myUser:myPassword@myHost.com:5432/myDb'
+        env['SERVICE_NAME_MAP'] = 'HEROKU_POSTGRESQL_RED_URL=myDatabase;foo=bar'
+        vcap_services = LibertyBuildpack::Util::Heroku.new.generate_vcap_services(env)
+
+        run_test(vcap_services)
+      end
+
+    end
+  end
+
+end

--- a/spec/liberty_buildpack/util/heroku_spec.rb
+++ b/spec/liberty_buildpack/util/heroku_spec.rb
@@ -1,0 +1,146 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'liberty_buildpack/util/heroku'
+
+module LibertyBuildpack::Util
+
+  describe 'Detect' do
+
+    after (:each) do
+      ENV.delete('DYNO')
+    end
+
+    it 'Heroku environment' do
+      ENV['DYNO'] = 'web.1'
+      expect(Heroku.heroku?).to be_true
+    end
+
+    it 'Non Heroku environment' do
+      ENV.delete('DYNO')
+      expect(Heroku.heroku?).to be_false
+    end
+
+  end
+
+  describe 'VCAP_SERVICES' do
+
+    def check_database_url(vcap_services)
+      services = vcap_services['DATABASE_URL']
+      expect(services).to have(1).items
+      expect(services[0]['name']).to match('database')
+      credentials = services[0]['credentials']
+      expect(credentials).to have(9).items
+      expect(credentials['host']).to match('foo')
+      expect(credentials['hostname']).to match('foo')
+      expect(credentials['port']).to eq(500)
+      expect(credentials['user']).to match('u')
+      expect(credentials['username']).to match('u')
+      expect(credentials['password']).to match('p')
+      expect(credentials['name']).to match('bar')
+      expect(credentials['uri']).to match('http://u:p@foo:500/bar')
+      expect(credentials['url']).to match('http://u:p@foo:500/bar')
+      tags = services[0]['tags']
+      expect(tags).to be_nil
+    end
+
+    def check_postgresql(vcap_services, expected_name)
+      services = vcap_services['HEROKU_POSTGRESQL_RED_URL']
+      expect(services).to have(1).items
+      expect(services[0]['name']).to match(expected_name)
+      credentials = services[0]['credentials']
+      expect(credentials).to have(4).items
+      expect(credentials['host']).to match('doesnotexist.xyz')
+      expect(credentials['hostname']).to match('doesnotexist.xyz')
+      expect(credentials['uri']).to match('postgre://doesnotexist.xyz')
+      expect(credentials['url']).to match('postgre://doesnotexist.xyz')
+      tags = services[0]['tags']
+      expect(tags).to include('postgresql')
+    end
+
+    def check_mysql(vcap_services, expected_name)
+      services = vcap_services['CLEARDB_DATABASE_URL']
+      expect(services).to have(1).items
+      expect(services[0]['name']).to match(expected_name)
+      credentials = services[0]['credentials']
+      expect(credentials).to have(8).items
+      expect(credentials['host']).to match('nnn.com')
+      expect(credentials['hostname']).to match('nnn.com')
+      expect(credentials['user']).to match('ggg')
+      expect(credentials['username']).to match('ggg')
+      expect(credentials['password']).to match('hhh')
+      expect(credentials['name']).to match('mmmm')
+      expect(credentials['uri']).to match('mysql://ggg:hhh@nnn.com/mmmm')
+      expect(credentials['url']).to match('mysql://ggg:hhh@nnn.com/mmmm')
+      tags = services[0]['tags']
+      expect(tags).to include('mysql')
+    end
+
+    def check_bad(vcap_services)
+      services = vcap_services['BAD_URL']
+      expect(services).to be_nil
+    end
+
+    it 'generate without service mappings' do
+      env = {}
+      env['DATABASE_URL'] = 'http://u:p@foo:500/bar'
+      env['HEROKU_POSTGRESQL_RED_URL'] = 'postgre://doesnotexist.xyz'
+      env['CLEARDB_DATABASE_URL'] = 'mysql://ggg:hhh@nnn.com/mmmm'
+      env['BAD_URL'] = '://badurl.xyz'
+
+      vcap_services = Heroku.new.generate_vcap_services(env)
+
+      # verify DATABASE_URL
+      check_database_url(vcap_services)
+
+      # verify HEROKU_POSTGRESQL_RED_URL
+      check_postgresql(vcap_services, 'postgresql.red')
+
+      # verify CLEARDB_DATABASE_URL
+      check_mysql(vcap_services, 'cleardb')
+
+      # verify BAD_URL
+      check_bad(vcap_services)
+    end
+
+    it 'generate with service mappings' do
+      env = {}
+      env['DATABASE_URL'] = 'http://u:p@foo:500/bar'
+      env['HEROKU_POSTGRESQL_RED_URL'] = 'postgre://doesnotexist.xyz'
+      env['CLEARDB_DATABASE_URL'] = 'mysql://ggg:hhh@nnn.com/mmmm'
+      env['BAD_URL'] = '://badurl.xyz'
+
+      env['SERVICE_NAME_MAP'] = 'HEROKU_POSTGRESQL_RED_URL=myDatabase; CLEARDB_DATABASE_URL = mysqlDb'
+
+      vcap_services = Heroku.new.generate_vcap_services(env)
+
+      # verify DATABASE_URL
+      check_database_url(vcap_services)
+
+      # verify HEROKU_POSTGRESQL_RED_URL
+      check_postgresql(vcap_services, 'myDatabase')
+
+      # verify CLEARDB_DATABASE_URL
+      check_mysql(vcap_services, 'mysqlDb')
+
+      # verify BAD_URL
+      check_bad(vcap_services)
+    end
+
+  end
+
+end


### PR DESCRIPTION
The following changes add support for auto-configuration for PostgreSQL and MySQL type of services on Bluemix, Pivotal, and Heroku platforms. Specifically, the PostgreSQL and MySQL service plugins added work with 1) PostgreSQL, MySQL, ElephantSQL, and ClearDB services on Bluemix, 2) ElephantSQL and ClearDB services on Pivotal, and 3) Heroku Postgres and ClearDB services on Heroku.

The PostgreSQL and MySQL service plugins have been configured with the same repository and driver version information as the Java buildpack. Also, tests are provided to simulate the different environments and services.
