### PR TITLE
Remove unnecessary /tmp directory since 1) it isn't used by any of the

### DIFF
--- a/spec/liberty_buildpack/jre/ibmjdk_spec.rb
+++ b/spec/liberty_buildpack/jre/ibmjdk_spec.rb
@@ -31,8 +31,6 @@ module LibertyBuildpack::Jre
       $stdout = StringIO.new
       $stderr = StringIO.new
 
-      FileUtils.rm_rf('/tmp/jre_temp')
-      Dir.mkdir('/tmp/jre_temp')
       # return license file by default
       application_cache.stub(:get).and_yield(File.open('spec/fixtures/license.html'))
     end


### PR DESCRIPTION
The rm -rf and mkdir commands that I've removed here contain a path for /tmp which doesn't make sense on any OS except Linux based OSes.  Additionally, none of the tests use this directory (as they all use Dir.mktmpdir now).  Furthermore, these lines can cause issues if more than one spec run is happening at a time.
