### PR TITLE
remove private_constant so that it works with older ruby versions

### DIFF
--- a/lib/liberty_buildpack/framework/java_opts.rb
+++ b/lib/liberty_buildpack/framework/java_opts.rb
@@ -66,8 +66,6 @@ module LibertyBuildpack::Framework
 
     ENVIRONMENT_PROPERTY = 'from_environment'.freeze
 
-    private_constant :JAVA_OPTS_PROPERTY, :ENVIRONMENT_PROPERTY, :JAVA_OPTS_PROPERTY
-
     def memory_option?(option)
       option =~ /-Xms/ || option =~ /-Xmx/ || option =~ /-XX:MaxMetaspaceSize/ || option =~ /-XX:MaxPermSize/ ||
         option =~ /-Xss/ || option =~ /-XX:MetaspaceSize/ || option =~ /-XX:PermSize/ if @jvm_type != nil && 'openjdk'.casecmp(@jvm_type) == 0


### PR DESCRIPTION
private_constant was introduced in Ruby 1.9.3. Unfortunately, some environments (i.e. Heroku) run with a slightly older version of Ruby (1.9.2).  I'm unable to find an easy way to force a different version of Ruby on Heroku so for now I'm hoping we can avoid using this keyword.
