### PR TITLE
disable configurtion, application, and dropins monitoring

### DIFF
--- a/lib/liberty_buildpack/container/liberty.rb
+++ b/lib/liberty_buildpack/container/liberty.rb
@@ -254,6 +254,10 @@ module LibertyBuildpack::Container
 
         # Disable default Liberty Welcome page to avoid returning 200 response before app is ready.
         disable_welcome_page(server_xml_doc)
+        # Disable application monitoring
+        disable_application_monitoring(server_xml_doc)
+        # Disable configuration (server.xml) monitoring
+        disable_config_monitoring(server_xml_doc)
         # Check if appstate ICAP feature can be used
         appstate_available = check_appstate_feature(server_xml_doc)
         @services_manager.update_configuration(server_xml_doc, false, current_server_dir)
@@ -302,6 +306,25 @@ module LibertyBuildpack::Container
       end
       webcontainer.add_attribute('trustHostHeaderPort', 'true')
       webcontainer.add_attribute('extractHostHeaderPort', 'true')
+    end
+
+    def disable_config_monitoring(server_xml_doc)
+      configs = REXML::XPath.match(server_xml_doc, '/server/config')
+      if configs.empty?
+        config = REXML::Element.new('config', server_xml_doc.root)
+        config.add_attribute('updateTrigger', 'mbean')
+      end
+    end
+
+    def disable_application_monitoring(server_xml_doc)
+      application_monitors = REXML::XPath.match(server_xml_doc, '/server/applicationMonitor')
+      if application_monitors.empty?
+        application_monitor = REXML::Element.new('applicationMonitor', server_xml_doc.root)
+        dropins_dir = File.join(current_server_dir, 'dropins')
+        dropins_dir_populated = Dir.exists?(dropins_dir) && Dir.entries(dropins_dir).size > 2
+        application_monitor.add_attribute('dropinsEnabled', dropins_dir_populated ? 'true' : 'false')
+        application_monitor.add_attribute('updateTrigger', 'mbean')
+      end
     end
 
     def disable_welcome_page(server_xml_doc)

--- a/resources/liberty/server.xml
+++ b/resources/liberty/server.xml
@@ -16,8 +16,7 @@
 
     <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${port}"/>
 
-        <application name="myapp" context-root="/" location="myapp"
-        type="war" />
+    <application name="myapp" context-root="/" location="myapp" type="war" />
         
     <logging logDirectory="${application.log.dir}"/>
 
@@ -28,4 +27,8 @@
     <httpDispatcher enableWelcomePage="false"/>
 
     <logging consoleLogLevel="INFO"/>
+
+    <applicationMonitor dropinsEnabled="false" updateTrigger="mbean"/>
+
+    <config updateTrigger="mbean"/>
 </server>


### PR DESCRIPTION
Disable configuration (server.xml), application, and dropins directory monitoring to safe some cpu cycles. This type of monitoring is unnecessary in CF. 
The updateTrigger is set to 'mbean' to allow configuration and application refresh via JMX.
The dropins directory monitoring is enabled or disabled based on the presence of the dropins directory in the server directory or package.
