### PR TITLE
handle YAML.load_file returning --- string

### DIFF
--- a/lib/liberty_buildpack/container/liberty.rb
+++ b/lib/liberty_buildpack/container/liberty.rb
@@ -138,9 +138,14 @@ module LibertyBuildpack::Container
       if File.exists? env_file
         env_contents = YAML.load_file(env_file)
         @logger.debug { "#{env_file} contents: #{env_contents}" }
+        if env_contents.nil? || '---'.eql?(env_contents)
+          env_contents = ''
+        else
+          # Converts {"foo"=>"bar"} to foo=bar so it can be part of the command string
+          env_contents = env_contents.to_s.gsub(/[{}>",]/, '')
+        end
       end
-      # Converts {"foo"=>"bar"} to foo=bar so it can be part of the command string
-      env_contents.to_s.gsub(/[{}>",]/, '')
+      env_contents
     end
 
     def jvm_options

--- a/spec/liberty_buildpack/container/liberty_spec.rb
+++ b/spec/liberty_buildpack/container/liberty_spec.rb
@@ -1460,6 +1460,26 @@ module LibertyBuildpack::Container
         end
       end
 
+      it 'should return correct output for empty env_yml_contents (older Ruby)' do
+        LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
+        .and_return(LIBERTY_VERSION)
+
+        YAML.stub(:load_file).and_return('---')
+
+        Dir.mktmpdir do |root|
+          FileUtils.cp_r('spec/fixtures/container_liberty', root)
+          contents = Liberty.new(
+            app_dir: File.join(root, 'container_liberty'),
+            java_home: 'test-java-home',
+            java_opts: '',
+            configuration: {},
+            license_ids: {}
+          ).release
+
+          expect(contents).to eq(".liberty/create_vars.rb .liberty/usr/servers/defaultServer/runtime-vars.xml && JAVA_HOME=\"$PWD/test-java-home\" .liberty/bin/server run defaultServer")
+        end
+      end
+
       it 'should return correct output for populated env_yml_contents' do
         LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
         .and_return(LIBERTY_VERSION)


### PR DESCRIPTION
It looks like on older Ruby versions YAML.load_file can return "---" string when loading an empty yml file. This can lead to a bad release command to be generated.
