### PR TITLE
update server.xml to let web-inf to be accessible

### DIFF
--- a/resources/liberty/server.xml
+++ b/resources/liberty/server.xml
@@ -22,7 +22,7 @@
 
     <include location="runtime-vars.xml" />
 
-    <webContainer trustHostHeaderPort="true" extractHostHeaderPort="true" />
+    <webContainer trustHostHeaderPort="true" extractHostHeaderPort="true" exposeWebInfOnDispatch="true"/>
     
     <httpDispatcher enableWelcomePage="false"/>
 


### PR DESCRIPTION
When we deploy the spring-music, we realized that the web-inf folder is disabled for liberty. Will it be nice to enable that so the migration from tomcat is more smoothy?

https://groups.google.com/a/cloudfoundry.org/forum/?utm_medium=email&utm_source=footer#!msg/vcap-dev/lC2KCxgMIXs/m2UvpWwHxxwJ
