### PR TITLE
check for JAVA_OPTS env. variable

### DIFF
--- a/lib/liberty_buildpack/framework/java_opts.rb
+++ b/lib/liberty_buildpack/framework/java_opts.rb
@@ -66,6 +66,8 @@ module LibertyBuildpack::Framework
 
     ENVIRONMENT_PROPERTY = 'from_environment'.freeze
 
+    ENVIRONMENT_VARIABLE = 'JAVA_OPTS'.freeze
+
     def memory_option?(option)
       option =~ /-Xms/ || option =~ /-Xmx/ || option =~ /-XX:MaxMetaspaceSize/ || option =~ /-XX:MaxPermSize/ ||
         option =~ /-Xss/ || option =~ /-XX:MetaspaceSize/ || option =~ /-XX:PermSize/ if @jvm_type != nil && 'openjdk'.casecmp(@jvm_type) == 0
@@ -75,7 +77,7 @@ module LibertyBuildpack::Framework
       parsed_java_opts = []
 
       parsed_java_opts.concat @configuration[JAVA_OPTS_PROPERTY].shellsplit if supports_configuration?
-      parsed_java_opts.concat @environment[JAVA_OPTS_PROPERTY].shellsplit if supports_environment?
+      parsed_java_opts.concat @environment[ENVIRONMENT_VARIABLE].shellsplit if supports_environment?
 
       parsed_java_opts.map { |java_opt| java_opt.gsub(/([\s])/, '\\\\\1') }
     end
@@ -85,7 +87,7 @@ module LibertyBuildpack::Framework
     end
 
     def supports_environment?
-      @configuration[ENVIRONMENT_PROPERTY] && @environment.key?(JAVA_OPTS_PROPERTY)
+      @configuration[ENVIRONMENT_PROPERTY] && @environment.key?(ENVIRONMENT_VARIABLE)
     end
 
   end

--- a/spec/liberty_buildpack/framework/java_opts_spec.rb
+++ b/spec/liberty_buildpack/framework/java_opts_spec.rb
@@ -38,7 +38,7 @@ module LibertyBuildpack::Framework
         java_opts: java_opts,
         app_dir: 'root',
         configuration: { 'java_opts' => '-Xmx1024M' },
-        environment: { 'java_opts' => '-Xms1024M' }
+        environment: { 'JAVA_OPTS' => '-Xms1024M' }
       ).detect
 
       expect(detected).to eq('java-opts')
@@ -59,7 +59,7 @@ module LibertyBuildpack::Framework
         java_opts: java_opts,
         app_dir: 'root',
         configuration: {},
-        environment: { 'java_opts' => '-Xms1024M' }
+        environment: { 'JAVA_OPTS' => '-Xms1024M' }
       ).detect
 
       expect(detected).to be_nil
@@ -83,7 +83,7 @@ module LibertyBuildpack::Framework
         java_opts: java_opts,
         app_dir: 'root',
         configuration: { 'from_environment' => true },
-        environment: { 'java_opts' => '-Xms1024M' }
+        environment: { 'JAVA_OPTS' => '-Xms1024M' }
       ).release
 
       expect(java_opts).to include('-Xms1024M')
@@ -94,7 +94,7 @@ module LibertyBuildpack::Framework
         java_opts: java_opts,
         app_dir: 'root',
         configuration: {},
-        environment: { 'java_opts' => '-Xms1024M' }
+        environment: { 'JAVA_OPTS' => '-Xms1024M' }
       ).release
 
       expect(java_opts).not_to include('-Xms1024M')


### PR DESCRIPTION
Fix code to check for JAVA_OPTS env. variable instead of java_opts. This makes it consistent with the Java buildpack as well. The documentation was already talking about JAVA_OPTS env. variable and does not need to be updated.
