### PR TITLE
use https

### DIFF
--- a/config/openjdk.yml
+++ b/config/openjdk.yml
@@ -15,5 +15,5 @@
 
 # Configuration for OpenJdk repository
 ---
-repository_root: "http://download.pivotal.io.s3.amazonaws.com/openjdk/lucid/x86_64"
+repository_root: "https://download.run.pivotal.io/openjdk/lucid/x86_64"
 version: 1.7.0_+

--- a/config/springautoreconfiguration.yml
+++ b/config/springautoreconfiguration.yml
@@ -18,4 +18,4 @@
 # avoid conflicts.
 ---
 version: 1.+
-repository_root: "http://download.run.pivotal.io/auto-reconfiguration"
+repository_root: "https://download.run.pivotal.io/auto-reconfiguration"

--- a/lib/liberty_buildpack/services/config/mongo.yml
+++ b/lib/liberty_buildpack/services/config/mongo.yml
@@ -23,4 +23,4 @@ features : ['mongodb-2.0']
 
 service_filter : '(?i)mongo'
 
-client_jar_url: http://central.maven.org/maven2/org/mongodb/mongo-java-driver/2.12.2/mongo-java-driver-2.12.2.jar
+client_jar_url: https://repo1.maven.org/maven2/org/mongodb/mongo-java-driver/2.12.2/mongo-java-driver-2.12.2.jar

--- a/lib/liberty_buildpack/services/config/mysql.yml
+++ b/lib/liberty_buildpack/services/config/mysql.yml
@@ -28,4 +28,4 @@ service_filter : 'mysql|cleardb'
 
 driver:
   version: 1.1.+
-  repository_root: "http://download.run.pivotal.io/mariadb-jdbc"
+  repository_root: "https://download.run.pivotal.io/mariadb-jdbc"

--- a/lib/liberty_buildpack/services/config/postgresql.yml
+++ b/lib/liberty_buildpack/services/config/postgresql.yml
@@ -28,4 +28,4 @@ service_filter : 'postgresql|elephantsql'
 
 driver:
   version: 9.3.+
-  repository_root: "http://download.run.pivotal.io/postgresql-jdbc"
+  repository_root: "https://download.run.pivotal.io/postgresql-jdbc"


### PR DESCRIPTION
Pivotal has fixed the certificate for https://download.run.pivotal.io so switch the configuration to use https url to download the binaries.
