### PR TITLE
Deprecation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,8 +46,8 @@ GEM
       simplecov (>= 0.4.1)
     slop (3.4.6)
     tee (1.0.0)
-    webmock (1.13.0)
-      addressable (>= 2.2.7)
+    webmock (1.18.0)
+      addressable (>= 2.3.6)
       crack (>= 0.3.2)
     yard (0.8.7)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,8 +28,13 @@ require 'liberty_buildpack/diagnostics/common'
 require 'liberty_buildpack/diagnostics/logger_factory'
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
+  config.expect_with :rspec do |c|
+    c.syntax = [:should, :expect]
+  end
+  config.mock_with :rspec do |c|
+    c.syntax = [:should, :expect]
+  end
   config.filter_run :focus
   # Ensure a logger exists for any class under test that needs one.
   config.before(:all) do


### PR DESCRIPTION
This is a follow on change to pull request #129 of the rspec3 refactoring work.  This change addresses the deprecated warning messages that result from moving to rspec3.
