### PR TITLE
Update the detect script output

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -24,22 +24,9 @@ require 'liberty_buildpack/buildpack'
 build_dir = ARGV[0]
 
 components = LibertyBuildpack::Buildpack.drive_buildpack_with_logger(build_dir, 'Detect failed with exception %s') { |buildpack| buildpack.detect }.compact
-detect_str = nil
+
 if components.empty?
   abort
 else
-  components.each do |comp|
-    if comp.start_with?('Liberty-')
-      liberty_type = comp.slice(0, comp.index(':') + 1)
-      comp.replace(comp.gsub(liberty_type, ''))
-      detect_str = liberty_type.gsub(':', ' (')
-      break
-    end
-  end
-end
-
-if detect_str
-  puts detect_str << components.join(', ') << ')'
-else
-  puts components.join(', ')
+  puts 'Liberty for Java(TM) (' << components.join(', ') << ')'
 end

--- a/lib/liberty_buildpack/buildpack.rb
+++ b/lib/liberty_buildpack/buildpack.rb
@@ -61,7 +61,7 @@ module LibertyBuildpack
       framework_detections = Buildpack.component_detections @frameworks
       container_detections = Buildpack.component_detections @containers
       raise "Application can not be run by more than one container: #{container_detections.join(', ')}" if container_detections.size > 1
-      tags = container_detections.empty? ? [] : [@jre_version].concat(framework_detections).concat(container_detections).flatten.compact
+      tags = container_detections.empty? ? [] : container_detections.concat([@jre_version]).concat(framework_detections).flatten.compact
       tags
     end
 

--- a/lib/liberty_buildpack/container/java_main.rb
+++ b/lib/liberty_buildpack/container/java_main.rb
@@ -51,7 +51,7 @@ module LibertyBuildpack::Container
     def detect
       if main_class
         @common_paths.relative_location = '../'
-        'Liberty-JAR:' << JavaMain.to_s.dash_case
+        ['JAR', JavaMain.to_s.dash_case]
       end
     end
 

--- a/lib/liberty_buildpack/container/liberty.rb
+++ b/lib/liberty_buildpack/container/liberty.rb
@@ -96,7 +96,7 @@ module LibertyBuildpack::Container
       liberty_version = Liberty.find_liberty_item(@app_dir, @configuration)[0]
       if liberty_version
         @common_paths.relative_location = relative_directory
-        [liberty_id(liberty_version)]
+        [liberty_type, liberty_id(liberty_version)]
       end
     end
 
@@ -655,20 +655,22 @@ module LibertyBuildpack::Container
       raise RuntimeError, "Liberty container error: #{e.message}", e.backtrace
     end
 
-    def liberty_id(version)
-      id = 'Liberty-'
+    def liberty_type
       if Liberty.web_inf(@app_dir)
-         id << 'WAR:'
+         type = 'WAR'
       elsif Liberty.meta_inf(@app_dir)
-         id << 'EAR:'
+         type = 'EAR'
       elsif Liberty.liberty_directory(@app_dir)
-         id << 'SVR-PKG:'
+         type = 'SVR-PKG'
       elsif Liberty.server_directory(@app_dir)
-         id << 'SVR-DIR:'
+         type = 'SVR-DIR'
       else
-         id = ''
+         type = 'unknown'
       end
-      id << "liberty-#{version}"
+    end
+
+    def liberty_id(version)
+      "liberty-#{version}"
     end
 
     def link_application

--- a/spec/bin/detect_spec.rb
+++ b/spec/bin/detect_spec.rb
@@ -19,12 +19,15 @@ require 'open3'
 
 describe 'detect script', :integration do
 
+  LIBERTY_FOR_JAVA = 'Liberty for Java(TM) ('.freeze
+
   it 'should return zero if success on the liberty WEB-INF case' do
     Dir.mktmpdir do |root|
       FileUtils.cp_r 'spec/fixtures/container_liberty/.', root
 
       with_memory_limit('1G') do
         Open3.popen3("bin/detect #{root}") do |stdin, stdout, stderr, wait_thr|
+          expect(stdout.read).to include(LIBERTY_FOR_JAVA + 'WAR')
           expect(wait_thr.value).to be_success
         end
       end
@@ -38,6 +41,7 @@ describe 'detect script', :integration do
 
       with_memory_limit('1G') do
         Open3.popen3("bin/detect #{root}") do |stdin, stdout, stderr, wait_thr|
+          expect(stdout.read).to include(LIBERTY_FOR_JAVA + 'SVR-PKG')
           expect(wait_thr.value).to be_success
         end
       end
@@ -51,6 +55,7 @@ describe 'detect script', :integration do
         FileUtils.cp_r 'spec/fixtures/framework_auto_reconfiguration_servlet_2/.', root
         with_memory_limit('1G') do
           Open3.popen3("bin/detect #{root}") do |stdin, stdout, stderr, wait_thr|
+            expect(stdout.read).to include(LIBERTY_FOR_JAVA + 'WAR')
             expect(wait_thr.value).to be_success
             expect(stderr.read).not_to include('undefined method')
           end
@@ -63,6 +68,7 @@ describe 'detect script', :integration do
     Dir.mktmpdir do |root|
       with_memory_limit('1G') do
         Open3.popen3("bin/detect #{root}") do |stdin, stdout, stderr, wait_thr|
+          expect(stdout.read).to_not include(LIBERTY_FOR_JAVA)
           expect(wait_thr.value).to_not be_success
         end
       end

--- a/spec/liberty_buildpack/container/java_main_spec.rb
+++ b/spec/liberty_buildpack/container/java_main_spec.rb
@@ -40,7 +40,7 @@ module LibertyBuildpack::Container
             configuration: {}
           ).detect
 
-          expect(detected).to eq('Liberty-JAR:java-main')
+          expect(detected).to eq(%w(JAR java-main))
         end
       end
 
@@ -51,7 +51,7 @@ module LibertyBuildpack::Container
             configuration: { 'java_main_class' => 'java-main' }
           ).detect
 
-          expect(detected).to eq('Liberty-JAR:java-main')
+          expect(detected).to eq(%w(JAR java-main))
         end
       end
 

--- a/spec/liberty_buildpack/container/liberty_spec.rb
+++ b/spec/liberty_buildpack/container/liberty_spec.rb
@@ -77,7 +77,7 @@ module LibertyBuildpack::Container
         license_ids: {}
         ).detect
 
-        expect(detected).to include('Liberty-WAR:liberty-8.5.5')
+        expect(detected).to eq(%w(WAR liberty-8.5.5))
       end
 
       it 'should detect META-INF' do
@@ -91,7 +91,7 @@ module LibertyBuildpack::Container
         license_ids: {}
         ).detect
 
-        expect(detected).to include('Liberty-EAR:liberty-8.5.5')
+        expect(detected).to eq(%w(EAR liberty-8.5.5))
       end
 
       it 'should not detect when WEB-INF is present in a Java main application' do
@@ -119,7 +119,7 @@ module LibertyBuildpack::Container
         license_ids: {}
         ).detect
 
-        expect(detected).to include('Liberty-SVR-PKG:liberty-8.5.5')
+        expect(detected).to eq(%w(SVR-PKG liberty-8.5.5))
       end
 
       it 'should detect server.xml for a single server push' do
@@ -133,7 +133,7 @@ module LibertyBuildpack::Container
         license_ids: {}
         ).detect
 
-        expect(detected).to include('Liberty-SVR-DIR:liberty-8.5.5')
+        expect(detected).to eq(%w(SVR-DIR liberty-8.5.5))
       end
 
       it 'should throw an error when a server including binaries was pushed' do


### PR DESCRIPTION
Update the detect script output such that the returned value is
a string which always begins with "Liberty for Java(TM)" and is
followed by other relevant information in parentheses.
