### PR TITLE
check the java file path relative to appdir

### DIFF
--- a/lib/liberty_buildpack/container/java_main.rb
+++ b/lib/liberty_buildpack/container/java_main.rb
@@ -121,7 +121,7 @@ module LibertyBuildpack::Container
       default_java_path = File.join('jre', 'bin', 'java')
       alt_java_path = File.join('bin', 'java')
 
-      if File.exists?(File.join(@java_home, default_java_path))
+      if File.exists?(File.join(@app_dir, @java_home, default_java_path))
         File.join(java_home, default_java_path)
       else
         File.join(java_home, alt_java_path)

--- a/spec/liberty_buildpack/container/java_main_spec.rb
+++ b/spec/liberty_buildpack/container/java_main_spec.rb
@@ -125,8 +125,8 @@ module LibertyBuildpack::Container
     describe 'release' do
       context 'default jre' do
         before do
-          allow(File).to receive(:exists?).with('.java/jre/bin/java').and_return(true)
-          allow(File).to receive(:exists?).with('.java/bin/java').and_return(false)
+          allow(File).to receive(:exists?).with(%r{.java/jre/bin/java}).and_return(true)
+          allow(File).to receive(:exists?).with(%r{.java/bin/java}).and_return(false)
         end
 
         it 'should return the java command' do
@@ -273,8 +273,8 @@ module LibertyBuildpack::Container
 
       context 'non jre' do
         it 'should return the java command adjusted for a nondefault java bin location' do
-          allow(File).to receive(:exists?).with('.java/jre/bin/java').and_return(false)
-          allow(File).to receive(:exists?).with('.java/bin/java').and_return(true)
+          allow(File).to receive(:exists?).with(%r{.java/jre/bin/java}).and_return(false)
+          allow(File).to receive(:exists?).with(%r{.java/bin/java}).and_return(true)
 
           Dir.mktmpdir do |root|
             released = JavaMain.new(


### PR DESCRIPTION
Checking for the java bin needs to be checked relative to the application directory.  This fix addresses deployment of standalone java applications.
