### PR TITLE
include JVM_ARGS support for jvm configuration

### DIFF
--- a/lib/liberty_buildpack/container/feature_manager.rb
+++ b/lib/liberty_buildpack/container/feature_manager.rb
@@ -68,11 +68,8 @@ module LibertyBuildpack::Container
           features = get_features(server_xml)
           jvm_args = get_jvm_args
           cmd = File.join(liberty_home, 'bin', 'featureManager')
-          if jvm_args.empty?
-            script_string = "JAVA_HOME=\"#{@app_dir}/#{@java_home}\" #{cmd} install --acceptLicense #{features} --when-file-exists=replace"
-          else
-            script_string = "JAVA_HOME=\"#{@app_dir}/#{@java_home}\" JVM_ARGS=#{jvm_args} #{cmd} install --acceptLicense #{features} --when-file-exists=replace"
-          end
+          script_string = "JAVA_HOME=\"#{@app_dir}/#{@java_home}\" JVM_ARGS=#{jvm_args} #{cmd} install --acceptLicense #{features} --when-file-exists=replace"
+
           @logger.debug("script invocation string is #{script_string}")
           output = `#{script_string}`
           # if ($CHILD_STATUS.to_i == 0) doesn't seem to work, as $CHILD_STATUS is

--- a/lib/liberty_buildpack/container/java_main.rb
+++ b/lib/liberty_buildpack/container/java_main.rb
@@ -66,10 +66,13 @@ module LibertyBuildpack::Container
     #
     # @return [String] the command to run the application.
     def release
+      java_opts = @java_opts.nil? || @java_opts.empty? ? nil : @java_opts
+
       [
         "#{java_bin}",
         manifest_class_path,
-        @java_opts.join(' '),
+        java_opts,
+        '$JVM_ARGS',
         main_class,
         arguments,
         port

--- a/lib/liberty_buildpack/container/liberty.rb
+++ b/lib/liberty_buildpack/container/liberty.rb
@@ -201,7 +201,7 @@ module LibertyBuildpack::Container
       minify_start_time = Time.now
       Dir.mktmpdir do |root|
         minified_zip = File.join(root, 'minified.zip')
-        minify_script_string = "JAVA_HOME=\"#{@app_dir}/#{@java_home}\" #{File.join(liberty_home, 'bin', 'server')} package #{server_name} --include=minify --archive=#{minified_zip} --os=-z/OS"
+        minify_script_string = "JAVA_HOME=\"#{@app_dir}/#{@java_home}\" JVM_ARGS="" #{File.join(liberty_home, 'bin', 'server')} package #{server_name} --include=minify --archive=#{minified_zip} --os=-z/OS"
         # Make it quiet unless there're errors (redirect only stdout)
         minify_script_string << ContainerUtils.space('1>/dev/null')
         system(minify_script_string)
@@ -605,7 +605,7 @@ module LibertyBuildpack::Container
       install_start_time = Time.now
       # setup the command and options
       cmd = File.join(root, WLP_PATH, 'bin', 'featureManager')
-      script_string = "JAVA_HOME=\"#{@app_dir}/#{@java_home}\" #{cmd} install #{file.path} #{options}"
+      script_string = "JAVA_HOME=\"#{@app_dir}/#{@java_home}\" JVM_ARGS="" #{cmd} install #{file.path} #{options}"
       output = `#{script_string}`
       if  $CHILD_STATUS.to_i != 0
         puts "\n #{output}"

--- a/lib/liberty_buildpack/jre/ibmjdk.rb
+++ b/lib/liberty_buildpack/jre/ibmjdk.rb
@@ -96,6 +96,7 @@ module LibertyBuildpack::Jre
     # @return [void]
     def release
       @java_opts.concat memory(@configuration)
+      @java_opts.concat default_dump_opts
     end
 
     # Prints a warning message if a memory limit of less than 512M has been chosen when using the IBM JDK.
@@ -111,8 +112,6 @@ module LibertyBuildpack::Jre
     private
 
     JAVA_HOME = '.java'.freeze
-
-    DUMP_HOME = '../../../../../dumps'.freeze
 
     KEY_MEMORY_HEURISTICS = 'memory_heuristics'
 
@@ -193,12 +192,14 @@ module LibertyBuildpack::Jre
       end
     end
 
-    # enable verbose gc logging to stderr and the dumps directory with historical
-    # number of logs of 10 with 1000 gc cycles
-    def default_opts_gc
+    # default options for -Xdump to disable dumps while routing to the default dumps location when it is enabled by the
+    # user
+    def default_dump_opts
       default_options = []
-      default_options.push('-verbose:gc')
-      default_options.push("-Xverbosegclog:#{@common_paths.log_directory}/verbosegc#.log,10,1000")
+      default_options.push "-Xdump:heap:defaults:file=#{@common_paths.dump_directory}/heapdump.%Y%m%d.%H%M%S.%pid.%seq.phd"
+      default_options.push "-Xdump:java:defaults:file=#{@common_paths.dump_directory}/javacore.%Y%m%d.%H%M%S.%pid.%seq.txt"
+      default_options.push "-Xdump:snap:defaults:file=#{@common_paths.dump_directory}/Snap.Y%m%d.%H%M%S.%pid.%seq.trc"
+      default_options.push '-Xdump:none'
       default_options
     end
 

--- a/spec/component_helper.rb
+++ b/spec/component_helper.rb
@@ -1,0 +1,35 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'application_helper'
+require 'console_helper'
+
+shared_context 'component_helper' do
+  include_context 'application_helper'
+  include_context 'console_helper'
+
+  let(:component) { described_class.new context }
+
+  let(:context) do |example|
+    { app_dir:        app_dir,
+      java_home:      example.metadata[:java_home],
+      java_opts:      example.metadata[:java_opts],
+      common_paths:   example.metadata[:common_paths],
+      configuration:  example.metadata[:configuration] }
+  end
+
+end

--- a/spec/liberty_buildpack/container/feature_manager_spec.rb
+++ b/spec/liberty_buildpack/container/feature_manager_spec.rb
@@ -180,6 +180,61 @@ module LibertyBuildpack::Container
       end
     end
 
+    context 'when JVM_ARGS is set by the user' do
+
+      JVM_ARGS_KEY = 'JVM_ARGS'.freeze
+
+      let(:prev_jvm_args) { 'user_jvm_args' }
+
+      before do
+        @previous_value = ENV[JVM_ARGS_KEY]
+      end
+
+      after do
+        ENV[JVM_ARGS_KEY] = @previous_value
+      end
+
+      it 'should not process preexisting JVM_ARGS when using the liberty feature repository' do
+        ENV[JVM_ARGS_KEY] = prev_jvm_args
+
+        Dir.mktmpdir do |root_dir|
+          # fixture files to be used.
+          configuration_file = File.join(FEATURE_REPOSITORY_FIXTURE_DIR, 'use_default_repo.yml')
+          feature_manager_script_file = File.join(FEATURE_REPOSITORY_FIXTURE_DIR, 'test_feature_manager_good_script')
+          server_xml_file = File.join(FEATURE_REPOSITORY_FIXTURE_DIR, 'test_server.xml')
+
+          # call feature manager using desired configuration and server.xml files.
+          app_dir, liberty_dir, liberty_bin_dir = set_up_feature_manager_script(root_dir, feature_manager_script_file)
+          call_feature_manager(app_dir, liberty_dir, configuration_file, server_xml_file)
+
+          # check liberty's featureManager was called, with expected parameters.
+          feature_manager_command_file = File.join(liberty_bin_dir, 'featureManager.txt')
+          expect(File.exists?(feature_manager_command_file)).to eq(true)
+          feature_manager_command = File.read feature_manager_command_file
+          expect(feature_manager_command).to match(/jvm args is \(\)/)
+        end
+      end
+
+      it 'should restore JVM_ARGS value when using the liberty feature repository' do
+        ENV[JVM_ARGS_KEY] = prev_jvm_args
+
+        Dir.mktmpdir do |root_dir|
+          # fixture files to be used.
+          configuration_file = File.join(FEATURE_REPOSITORY_FIXTURE_DIR, 'use_default_repo.yml')
+          feature_manager_script_file = File.join(FEATURE_REPOSITORY_FIXTURE_DIR, 'test_feature_manager_good_script')
+          server_xml_file = File.join(FEATURE_REPOSITORY_FIXTURE_DIR, 'test_server.xml')
+
+          # call feature manager using desired configuration and server.xml files.
+          app_dir, liberty_dir  = set_up_feature_manager_script(root_dir, feature_manager_script_file)
+          call_feature_manager(app_dir, liberty_dir, configuration_file, server_xml_file)
+
+          # check that the JVM_ARGS has the same value from prior to running feature manager
+          expect(ENV['JVM_ARGS']).to match(prev_jvm_args)
+        end
+      end
+
+    end # end of JVM_ARGS context
+
   end # describe
 
 end # module

--- a/spec/liberty_buildpack/container/java_main_spec.rb
+++ b/spec/liberty_buildpack/container/java_main_spec.rb
@@ -15,84 +15,70 @@
 # the License.
 
 require 'spec_helper'
+require 'component_helper'
 require 'liberty_buildpack/container/java_main'
 require 'liberty_buildpack/container/container_utils'
 
 module LibertyBuildpack::Container
 
   describe JavaMain do
+    include_context 'component_helper'
 
-    before do
+    before do |example|
       $stdout = StringIO.new
       $stderr = StringIO.new
-    end
 
-    describe 'detect' do
-      it 'should detect main class in manifest' do
-        Dir.mktmpdir do |root|
-          FileUtils.mkdir_p File.join(root, 'META-INF')
-          File.open(File.join(root, 'META-INF', 'MANIFEST.MF'), 'w') do |file|
-            file.write('Main-Class: detect.test')
-          end
-
-          detected = JavaMain.new(
-            app_dir: root,
-            configuration: {}
-          ).detect
-
-          expect(detected).to eq(%w(JAR java-main))
+      # JavaMain tests can specify what needs to be written to the META-INF/MANIFEST.MF
+      java_main_manifest = example.metadata[:java_main_manifest]
+      if java_main_manifest
+        FileUtils.mkdir_p File.join(app_dir, 'META-INF')
+        File.open(File.join(app_dir, 'META-INF', 'MANIFEST.MF'), 'w') do |file|
+          file.write(java_main_manifest)
         end
       end
+    end
 
-      it 'should detect main class in configuration' do
-        Dir.mktmpdir do |root|
-          detected = JavaMain.new(
-            app_dir: root,
-            configuration: { 'java_main_class' => 'java-main' }
-          ).detect
+    describe 'detect', configuration: {} do
 
-          expect(detected).to eq(%w(JAR java-main))
-        end
+      subject(:detected) do |example|
+        JavaMain.new(context).detect
+      end
+
+      it 'should detect main class in manifest',
+         java_main_manifest: 'Main-Class: detect.test' do
+
+        expect(detected).to eq(%w(JAR java-main))
+      end
+
+      it 'should detect main class in configuration',
+         configuration: { 'java_main_class' => 'java-main' } do
+
+        expect(detected).to eq(%w(JAR java-main))
       end
 
       it 'should not detect without manifest' do
-        Dir.mktmpdir do |root|
-
-          detected = JavaMain.new(
-           app_dir: root,
-           configuration: {}
-          ).detect
-
-          expect(detected).to be_nil
-        end
+        expect(detected).to be_nil
       end
 
-      it 'should update the common_paths provided by the buildpack to include the Standalone Java container path' do
-        Dir.mktmpdir do |root|
+      describe 'the relative location returned by common paths after detect gets invoked' do
+        subject(:relative_location) do |example|
+          java_main = JavaMain.new(context)
+          java_main.detect
+          actual_common_paths = java_main.instance_variable_get(:@common_paths)
+          actual_common_paths.instance_variable_get(:@relative_location)
+        end
 
-          java_main = JavaMain.new(
-           app_dir: root,
+        it 'should update the common_paths provided by the buildpack to include the Standalone Java container path',
            common_paths: CommonPaths.new,
-           configuration: { 'java_main_class' => 'java-main' }
-          )
-          java_main.detect
+           configuration: { 'java_main_class' => 'java-main' } do
 
-          actual_common_paths = java_main.instance_variable_get(:@common_paths)
-          expect(actual_common_paths.instance_variable_get(:@relative_location)).to eq('../')
+          expect(relative_location).to eq('../')
         end
-      end
 
-      it 'should result with Java Standalone path when the common_paths is not provided in its context' do
-        Dir.mktmpdir do |root|
+        it 'should result with Java Standalone path when the common_paths is not provided in its context',
+           configuration: { 'java_main_class' => 'java-main' } do
 
-          java_main = JavaMain.new(
-           app_dir: root,
-           configuration: { 'java_main_class' => 'java-main' }
-          )
-          java_main.detect
-
-          actual_common_paths = java_main.instance_variable_get(:@common_paths)
-          expect(actual_common_paths.instance_variable_get(:@relative_location)).to eq('../')
+          expect(relative_location).to eq('../')
         end
       end
     end
@@ -110,10 +96,10 @@ module LibertyBuildpack::Container
           end
 
           JavaMain.new(
-          app_dir: root,
-          java_home: '.java',
-          java_opts: [],
-          configuration: { 'java_main_class' => 'com.ibm.rspec.test' }
+            app_dir: root,
+            java_home: '.java',
+            java_opts: [],
+            configuration: { 'java_main_class' => 'com.ibm.rspec.test' }
           ).compile
 
           expect(File.exists?(File.join root, '.java', 'overlay.txt')).to eq(true)
@@ -122,173 +108,104 @@ module LibertyBuildpack::Container
       end
     end
 
-    describe 'release' do
-      context 'default jre' do
+    describe 'release',
+             java_home: '.java',
+             java_opts: [],
+             configuration: {} do
+
+      subject(:released) { JavaMain.new(context).release }
+
+      it 'should include command line argument JVM_ARGS',
+         configuration: { 'java_main_class' => 'com.ibm.rspec.test' } do
+
+        expect(released).to include('java $JVM_ARGS com.ibm.rspec.test')
+      end
+
+      it 'should include command line argument JVM_ARGS after JAVA_OPTS values',
+         java_opts: %w(user_java_opts1 user_java_opts2),
+         configuration: { 'java_main_class' => 'com.ibm.rspec.test' } do
+
+        expect(released).to include('java user_java_opts1 user_java_opts2 $JVM_ARGS com.ibm.rspec.test')
+      end
+
+      it 'should return command line arguments when they are specified',
+         configuration: {
+            'java_main_class' => 'com.ibm.rspec.test',
+            'arguments' => 'some arguments' } do
+
+        expect(released).to include('com.ibm.rspec.test some arguments')
+      end
+
+      it 'should return classpath entries when Class-Path is specified.',
+         java_main_manifest: 'Class-Path: additional_libs/test-jar-1.jar test-jar-2.jar' do
+
+        expect(released).to include('-cp $PWD/additional_libs/test-jar-1.jar:$PWD/test-jar-2.jar')
+      end
+
+      it 'should return spring boot applications with a JarLauncher in manifest',
+         java_main_manifest: 'Main-Class: org.springframework.boot.loader.JarLauncher' do
+
+        expect(released).to include('org.springframework.boot.loader.JarLauncher --server.port=$PORT')
+      end
+
+      it 'should return spring boot applications with a WarLauncher in manifest',
+         java_main_manifest: 'Main-Class: org.springframework.boot.loader.WarLauncher' do
+
+        expect(released).to include('org.springframework.boot.loader.WarLauncher --server.port=$PORT')
+      end
+
+      it 'should return spring boot applications with a PropertiesLauncher in manifest',
+         java_main_manifest: 'Main-Class: org.springframework.boot.loader.PropertiesLauncher' do
+
+        expect(released).to include('org.springframework.boot.loader.PropertiesLauncher --server.port=$PORT')
+      end
+
+      it 'should return spring boot applications with a JarLauncher in configuration',
+         configuration: { 'java_main_class' => 'org.springframework.boot.loader.JarLauncher' } do
+
+        expect(released).to include('org.springframework.boot.loader.JarLauncher --server.port=$PORT')
+      end
+
+      it 'should return spring boot applications with a WarLauncher in configuration',
+         configuration: { 'java_main_class' => 'org.springframework.boot.loader.WarLauncher' } do
+
+        expect(released).to include('org.springframework.boot.loader.WarLauncher --server.port=$PORT')
+      end
+
+      it 'should return spring boot applications with a PropertiesLauncher in configuration',
+         configuration: { 'java_main_class' => 'org.springframework.boot.loader.PropertiesLauncher' } do
+
+        expect(released).to include('org.springframework.boot.loader.PropertiesLauncher --server.port=$PORT')
+      end
+
+      context 'default path which has jre in it' do
+
         before do
           allow(File).to receive(:exists?).with(%r{.java/jre/bin/java}).and_return(true)
           allow(File).to receive(:exists?).with(%r{.java/bin/java}).and_return(false)
         end
 
-        it 'should return the java command' do
-          Dir.mktmpdir do |root|
-            released = JavaMain.new(
-            app_dir: root,
-            java_home: '.java',
-            java_opts: [],
-            configuration: { 'java_main_class' => 'com.ibm.rspec.test' }
-            ).release
+        it 'should return the java command',
+           configuration: { 'java_main_class' => 'com.ibm.rspec.test' } do
 
-            expect(released).to include('$PWD/.java/jre/bin/java')
-          end
+          expect(released).to include('$PWD/.java/jre/bin/java')
         end
 
-        it 'should return classpath entries when Class-Path is specified.' do
-          Dir.mktmpdir do |root|
-            FileUtils.mkdir_p File.join(root, 'META-INF')
-            File.open(File.join(root, 'META-INF', 'MANIFEST.MF'), 'w') do |file|
-              file.write('Class-Path: additional_libs/test-jar-1.jar test-jar-2.jar')
-            end
-
-            detected = JavaMain.new(
-              app_dir: root,
-              java_home: '.java',
-              java_opts: [],
-              configuration: {}
-            ).release
-
-            expect(detected).to include('-cp $PWD/additional_libs/test-jar-1.jar:$PWD/test-jar-2.jar')
-          end
-        end
-
-        it 'should return command line arguments when they are specified' do
-          Dir.mktmpdir do |root|
-
-            detected = JavaMain.new(
-              app_dir: root,
-              java_home: '.java',
-              java_opts: [],
-              configuration: { 'java_main_class' => 'com.ibm.rspec.test', 'arguments' => 'some arguments' }
-            ).release
-
-            expect(detected).to include('com.ibm.rspec.test some arguments')
-          end
-        end
-
-        it 'should return spring boot applications with a JarLauncher in manifest' do
-          Dir.mktmpdir do |root|
-            FileUtils.mkdir_p File.join(root, 'META-INF')
-            File.open(File.join(root, 'META-INF', 'MANIFEST.MF'), 'w') do |file|
-              file.write('Main-Class: org.springframework.boot.loader.JarLauncher')
-            end
-
-            detected = JavaMain.new(
-              app_dir: root,
-              java_home: '.java',
-              java_opts: [],
-              configuration: {}
-            ).release
-
-            expect(detected).to include('org.springframework.boot.loader.JarLauncher --server.port=$PORT')
-          end
-        end
-
-        it 'should return spring boot applications with a WarLauncher in manifest' do
-          Dir.mktmpdir do |root|
-            FileUtils.mkdir_p File.join(root, 'META-INF')
-            File.open(File.join(root, 'META-INF', 'MANIFEST.MF'), 'w') do |file|
-              file.write('Main-Class: org.springframework.boot.loader.WarLauncher')
-            end
-
-            detected = JavaMain.new(
-              app_dir: root,
-              java_home: '.java',
-              java_opts: [],
-              configuration: {}
-            ).release
-
-            expect(detected).to include('org.springframework.boot.loader.WarLauncher --server.port=$PORT')
-          end
-        end
-
-        it 'should return spring boot applications with a PropertiesLauncher in manifest' do
-          Dir.mktmpdir do |root|
-            FileUtils.mkdir_p File.join(root, 'META-INF')
-            File.open(File.join(root, 'META-INF', 'MANIFEST.MF'), 'w') do |file|
-              file.write('Main-Class: org.springframework.boot.loader.PropertiesLauncher')
-            end
-
-            detected = JavaMain.new(
-              app_dir: root,
-              java_home: '.java',
-              java_opts: [],
-              configuration: {}
-            ).release
-
-            expect(detected).to include('org.springframework.boot.loader.PropertiesLauncher --server.port=$PORT')
-          end
-        end
-
-        it 'should return spring boot applications with a JarLauncher in configuration' do
-          Dir.mktmpdir do |root|
-
-            detected = JavaMain.new(
-              app_dir: root,
-              java_home: '.java',
-              java_opts: [],
-              configuration: { 'java_main_class' => 'org.springframework.boot.loader.JarLauncher' }
-            ).release
-
-            expect(detected).to include('org.springframework.boot.loader.JarLauncher --server.port=$PORT')
-          end
-        end
-
-        it 'should return spring boot applications with a WarLauncher in configuration' do
-          Dir.mktmpdir do |root|
-
-            detected = JavaMain.new(
-              app_dir: root,
-              java_home: '.java',
-              java_opts: [],
-              configuration: { 'java_main_class' => 'org.springframework.boot.loader.WarLauncher' }
-            ).release
-
-            expect(detected).to include('org.springframework.boot.loader.WarLauncher --server.port=$PORT')
-          end
-        end
-
-        it 'should return spring boot applications with a PropertiesLauncher in configuration' do
-          Dir.mktmpdir do |root|
-
-            detected = JavaMain.new(
-              app_dir: root,
-              java_home: '.java',
-              java_opts: [],
-              configuration: { 'java_main_class' => 'org.springframework.boot.loader.PropertiesLauncher' }
-            ).release
-
-            expect(detected).to include('org.springframework.boot.loader.PropertiesLauncher --server.port=$PORT')
-          end
-        end
       end # end of default jre context
 
-      context 'non jre' do
-        it 'should return the java command adjusted for a nondefault java bin location' do
+      context 'paths that do not have jre in it' do
+
+        before do
           allow(File).to receive(:exists?).with(%r{.java/jre/bin/java}).and_return(false)
           allow(File).to receive(:exists?).with(%r{.java/bin/java}).and_return(true)
+        end
 
-          Dir.mktmpdir do |root|
-            released = JavaMain.new(
-            app_dir: root,
-            java_home: '.java',
-            java_opts: [],
-            configuration: { 'java_main_class' => 'com.ibm.rspec.test' }
-            ).release
+        it 'should return the java command adjusted for a nondefault java bin location',
+           configuration: { 'java_main_class' => 'com.ibm.rspec.test' } do
 
-            expect(released).to include('$PWD/.java/bin/java')
-          end
+          expect(released).to include('$PWD/.java/bin/java')
         end
       end
-
     end # end of release describe
 
   end

--- a/spec/liberty_buildpack/jre/ibmjdk_spec.rb
+++ b/spec/liberty_buildpack/jre/ibmjdk_spec.rb
@@ -216,6 +216,27 @@ module LibertyBuildpack::Jre
       end
     end
 
+    it 'should add default dump options that output data to the common dumps directory, if enabled' do
+       Dir.mktmpdir do |root|
+         LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item).and_return(DETAILS_PRE_8)
+         common_paths = LibertyBuildpack::Container::CommonPaths.new
+
+         released = IBMJdk.new(
+             app_dir: '/application-directory',
+             java_home: '',
+             java_opts: [],
+             common_paths: common_paths,
+             configuration: {},
+             license_ids: {}
+         ).release
+
+         expect(released).to include('-Xdump:heap:defaults:file=' + common_paths.dump_directory + '/heapdump.%Y%m%d.%H%M%S.%pid.%seq.phd')
+         expect(released).to include('-Xdump:java:defaults:file=' + common_paths.dump_directory + '/javacore.%Y%m%d.%H%M%S.%pid.%seq.txt')
+         expect(released).to include('-Xdump:snap:defaults:file=' + common_paths.dump_directory + '/Snap.Y%m%d.%H%M%S.%pid.%seq.trc')
+         expect(released.last).to eq('-Xdump:none')
+       end
+    end
+
     it 'should used -Xnocompressedrefs when the memory limit is less than 256m' do
       Dir.mktmpdir do |root|
         LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item).and_return(DETAILS_PRE_8)


### PR DESCRIPTION
Added support for JVM_ARGS, an environment variable available for the Liberty Runtime, for jvm configuration.
