### PR TITLE
Refactor setting buildpack env. variables as a framework

### DIFF
--- a/config/components.yml
+++ b/config/components.yml
@@ -22,5 +22,6 @@ jres:
   - "LibertyBuildpack::Jre::IBMJdk"
   - "LibertyBuildpack::Jre::OpenJdk"
 frameworks:
+  - "LibertyBuildpack::Framework::Env"
   - "LibertyBuildpack::Framework::JavaOpts"
   - "LibertyBuildpack::Framework::SpringAutoReconfiguration"

--- a/lib/liberty_buildpack/container/liberty.rb
+++ b/lib/liberty_buildpack/container/liberty.rb
@@ -128,13 +128,12 @@ module LibertyBuildpack::Container
       server_dir = ' .liberty/usr/servers/' << server_name << '/'
       runtime_vars_file =  server_dir + 'runtime-vars.xml'
       create_vars_string = File.join(LIBERTY_HOME, 'create_vars.rb') << runtime_vars_file << ' &&'
-      env_var_string = ContainerUtils.space(env_yml_contents)
       java_home_string = ContainerUtils.space("JAVA_HOME=\"$PWD/#{@java_home}\"")
       start_script_string = ContainerUtils.space(File.join(LIBERTY_HOME, 'bin', 'server'))
       start_script_string << ContainerUtils.space('run')
       jvm_options
       server_name_string = ContainerUtils.space(server_name)
-      "#{create_vars_string}#{env_var_string}#{java_home_string}#{start_script_string}#{server_name_string}"
+      "#{create_vars_string}#{java_home_string}#{start_script_string}#{server_name_string}"
     end
 
     # relative location of the execution directory
@@ -147,22 +146,6 @@ module LibertyBuildpack::Container
     end
 
     private
-
-    def env_yml_contents
-      env_contents = ''
-      env_file = File.expand_path('../../../config/env.yml', File.dirname(__FILE__))
-      if File.exists? env_file
-        env_contents = YAML.load_file(env_file)
-        @logger.debug { "#{env_file} contents: #{env_contents}" }
-        if env_contents.nil? || '---'.eql?(env_contents)
-          env_contents = ''
-        else
-          # Converts {"foo"=>"bar"} to foo=bar so it can be part of the command string
-          env_contents = env_contents.to_s.gsub(/[{}>",]/, '')
-        end
-      end
-      env_contents
-    end
 
     def jvm_options
       # disable 2-phase (XA) transactions via a -D option, as they are unsupported in

--- a/lib/liberty_buildpack/framework/env.rb
+++ b/lib/liberty_buildpack/framework/env.rb
@@ -1,0 +1,80 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2013-2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'liberty_buildpack/framework'
+require 'liberty_buildpack/util/dash_case'
+require 'liberty_buildpack/diagnostics/logger_factory'
+
+module LibertyBuildpack::Framework
+
+  # Encapsulates the detect, compile, and release functionality for contributing custom environment variables
+  # to an application at runtime.
+  class Env
+
+    # Creates an instance, passing in an arbitrary collection of options.
+    #
+    # @param [Hash] context the context that is provided to the instance
+    # @option context [String] :app_dir the directory that the application exists in
+    # @option context [Hash] :configuration the properties provided by the user
+    def initialize(context = {})
+      @logger = LibertyBuildpack::Diagnostics::LoggerFactory.get_logger
+      @configuration = context[:configuration]
+      @app_dir = context[:app_dir]
+    end
+
+    # Detects whether the buildpack provides custom environment variables.
+    #
+    # @return [String] returns +env+ if custom environment variables are set.
+    def detect
+      has_configuration? ? Env.to_s.dash_case : nil
+    end
+
+    # Create .profile.d/env.sh with the custom environment variables.
+    #
+    # @return [void]
+    def compile
+      profiled_dir = File.join(@app_dir, '.profile.d')
+      FileUtils.mkdir_p(profiled_dir)
+
+      variables = []
+      @configuration.each do | key, value |
+        key = key.strip
+        variables << "export #{key}=\"#{value}\"" unless key.empty?
+      end
+
+      @logger.debug { "Buildpack environment variables: #{variables}" }
+
+      env_file_name = File.join(profiled_dir, 'env.sh')
+      env_file = File.new(env_file_name, 'w')
+      env_file.puts(variables)
+      env_file.close
+    end
+
+    # No op.
+    #
+    # @return [void]
+    def release
+    end
+
+    private
+
+    def has_configuration?
+      !@configuration.nil? && @configuration.size > 0
+    end
+
+  end
+
+end

--- a/spec/liberty_buildpack/container/liberty_spec.rb
+++ b/spec/liberty_buildpack/container/liberty_spec.rb
@@ -1484,73 +1484,10 @@ module LibertyBuildpack::Container
 
       end # end of JVM Options Context
 
-      it 'should return correct output for empty env_yml_contents' do
-        LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
-        .and_return(LIBERTY_VERSION)
-
-        yaml = Hash.new
-        YAML.stub(:load_file).and_return(yaml)
-
-        Dir.mktmpdir do |root|
-          FileUtils.cp_r('spec/fixtures/container_liberty', root)
-          contents = Liberty.new(
-            app_dir: File.join(root, 'container_liberty'),
-            java_home: test_java_home,
-            java_opts: '',
-            configuration: {},
-            license_ids: {}
-          ).release
-
-          expect(contents).to eq(".liberty/create_vars.rb .liberty/usr/servers/defaultServer/runtime-vars.xml && JAVA_HOME=\"$PWD/#{test_java_home}\" .liberty/bin/server run defaultServer")
-        end
-      end
-
-      it 'should return correct output for empty env_yml_contents (older Ruby)' do
-        LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
-        .and_return(LIBERTY_VERSION)
-
-        YAML.stub(:load_file).and_return('---')
-
-        Dir.mktmpdir do |root|
-          FileUtils.cp_r('spec/fixtures/container_liberty', root)
-          contents = Liberty.new(
-            app_dir: File.join(root, 'container_liberty'),
-            java_home: test_java_home,
-            java_opts: '',
-            configuration: {},
-            license_ids: {}
-          ).release
-
-          expect(contents).to eq(".liberty/create_vars.rb .liberty/usr/servers/defaultServer/runtime-vars.xml && JAVA_HOME=\"$PWD/#{test_java_home}\" .liberty/bin/server run defaultServer")
-        end
-      end
-
-      it 'should return correct output for populated env_yml_contents' do
-        LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
-        .and_return(LIBERTY_VERSION)
-
-        yaml = YAML.load('testURL: http://exampleurl.ibm.com')
-        YAML.stub(:load_file).and_return(yaml)
-
-        Dir.mktmpdir do |root|
-          FileUtils.cp_r('spec/fixtures/container_liberty', root)
-          contents = Liberty.new(
-            app_dir: File.join(root, 'container_liberty'),
-            java_home: test_java_home,
-            java_opts: '',
-            configuration: {},
-            license_ids: {}
-          ).release
-
-          expect(contents).to eq(".liberty/create_vars.rb .liberty/usr/servers/defaultServer/runtime-vars.xml && testURL=http://exampleurl.ibm.com JAVA_HOME=\"$PWD/#{test_java_home}\" .liberty/bin/server run defaultServer")
-        end
-      end
-
       it 'should return correct execution command for the WEB-INF case' do
         LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
         .and_return(LIBERTY_VERSION)
 
-        allow_any_instance_of(Liberty).to receive(:env_yml_contents).and_return('')
         Dir.mktmpdir do |root|
           FileUtils.cp_r('spec/fixtures/container_liberty', root)
           command = Liberty.new(
@@ -1562,26 +1499,6 @@ module LibertyBuildpack::Container
           ).release
 
           expect(command).to eq(".liberty/create_vars.rb .liberty/usr/servers/defaultServer/runtime-vars.xml && JAVA_HOME=\"$PWD/#{test_java_home}\" .liberty/bin/server run defaultServer")
-        end
-      end
-
-      it 'should return correct execution command for the WEB-INF case with env.yml' do
-        LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
-        .and_return(LIBERTY_VERSION)
-
-        allow_any_instance_of(Liberty).to receive(:env_yml_contents).and_return('foo=http://bar.com')
-
-        Dir.mktmpdir do |root|
-          FileUtils.cp_r('spec/fixtures/container_liberty', root)
-          command = Liberty.new(
-            app_dir: File.join(root, 'container_liberty'),
-            java_home: test_java_home,
-            java_opts: '',
-            configuration: {},
-            license_ids: {}
-          ).release
-
-          expect(command).to eq(".liberty/create_vars.rb .liberty/usr/servers/defaultServer/runtime-vars.xml && foo=http://bar.com JAVA_HOME=\"$PWD/#{test_java_home}\" .liberty/bin/server run defaultServer")
         end
       end
 
@@ -1589,7 +1506,6 @@ module LibertyBuildpack::Container
         LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
         .and_return(LIBERTY_VERSION)
 
-        allow_any_instance_of(Liberty).to receive(:env_yml_contents).and_return('')
         Dir.mktmpdir do |root|
           FileUtils.cp_r('spec/fixtures/container_liberty_ear', root)
           command = Liberty.new(
@@ -1604,31 +1520,10 @@ module LibertyBuildpack::Container
         end
       end
 
-      it 'should return correct execution command for the META-INF case with env.yml' do
-        LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
-        .and_return(LIBERTY_VERSION)
-
-        allow_any_instance_of(Liberty).to receive(:env_yml_contents).and_return('foo=http://bar.com')
-
-        Dir.mktmpdir do |root|
-          FileUtils.cp_r('spec/fixtures/container_liberty_ear', root)
-          command = Liberty.new(
-            app_dir: File.join(root, 'container_liberty_ear'),
-            java_home: test_java_home,
-            java_opts: '',
-            configuration: {},
-            license_ids: {}
-          ).release
-
-          expect(command).to eq(".liberty/create_vars.rb .liberty/usr/servers/defaultServer/runtime-vars.xml && foo=http://bar.com JAVA_HOME=\"$PWD/#{test_java_home}\" .liberty/bin/server run defaultServer")
-        end
-      end
-
       it 'should return correct execution command for the zipped-up server case' do
         LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
         .and_return(LIBERTY_VERSION)
 
-        allow_any_instance_of(Liberty).to receive(:env_yml_contents).and_return('')
         Dir.mktmpdir do |root|
           FileUtils.cp_r('spec/fixtures/container_liberty_server', root)
           command = Liberty.new(
@@ -1643,31 +1538,10 @@ module LibertyBuildpack::Container
         end
       end
 
-      it 'should return correct execution command for the zipped-up server case with env.yml' do
-        LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
-        .and_return(LIBERTY_VERSION)
-
-        allow_any_instance_of(Liberty).to receive(:env_yml_contents).and_return('foo=http://bar.com')
-
-        Dir.mktmpdir do |root|
-          FileUtils.cp_r('spec/fixtures/container_liberty_server', root)
-          command = Liberty.new(
-            app_dir: File.join(root, 'container_liberty_server'),
-            java_home: test_java_home,
-            java_opts: '',
-            configuration: {},
-            license_ids: {}
-          ).release
-
-          expect(command).to eq(".liberty/create_vars.rb .liberty/usr/servers/myServer/runtime-vars.xml && foo=http://bar.com JAVA_HOME=\"$PWD/#{test_java_home}\" .liberty/bin/server run myServer")
-        end
-      end
-
       it 'should return correct execution command for single-server case' do
         LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
         .and_return(LIBERTY_VERSION)
 
-        allow_any_instance_of(Liberty).to receive(:env_yml_contents).and_return('')
         Dir.mktmpdir do |root|
           FileUtils.cp_r('spec/fixtures/container_liberty_single_server', root)
           command = Liberty.new(
@@ -1679,26 +1553,6 @@ module LibertyBuildpack::Container
           ).release
 
           expect(command).to eq(".liberty/create_vars.rb .liberty/usr/servers/defaultServer/runtime-vars.xml && JAVA_HOME=\"$PWD/#{test_java_home}\" .liberty/bin/server run defaultServer")
-        end
-      end
-
-      it 'should return correct execution command for single-server case with env.yml' do
-        LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
-        .and_return(LIBERTY_VERSION)
-
-        allow_any_instance_of(Liberty).to receive(:env_yml_contents).and_return('foo=http://bar.com')
-
-        Dir.mktmpdir do |root|
-          FileUtils.cp_r('spec/fixtures/container_liberty_single_server', root)
-          command = Liberty.new(
-            app_dir: File.join(root, 'container_liberty_single_server'),
-            java_home: test_java_home,
-            java_opts: '',
-            configuration: {},
-            license_ids: {}
-          ).release
-
-          expect(command).to eq(".liberty/create_vars.rb .liberty/usr/servers/defaultServer/runtime-vars.xml && foo=http://bar.com JAVA_HOME=\"$PWD/#{test_java_home}\" .liberty/bin/server run defaultServer")
         end
       end
 

--- a/spec/liberty_buildpack/framework/env_spec.rb
+++ b/spec/liberty_buildpack/framework/env_spec.rb
@@ -1,0 +1,71 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2013-2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'liberty_buildpack/framework/env'
+
+module LibertyBuildpack::Framework
+
+  describe Env do
+
+    it 'should detect with env configuration' do
+      detected = Env.new(
+        app_dir: 'root',
+        configuration: { 'foo' => 'http://bar.com' }
+      ).detect
+
+      expect(detected).to eq('env')
+    end
+
+    it 'should not detect with empty env configuration' do
+      detected = Env.new(
+        app_dir: 'root',
+        configuration: {}
+      ).detect
+
+      expect(detected).to be_nil
+    end
+
+    it 'should not detect with nil env configuration' do
+      detected = Env.new(
+        app_dir: 'root',
+        configuration: nil
+      ).detect
+
+      expect(detected).to be_nil
+    end
+
+    it 'should create env.sh with env configuration' do
+      Dir.mktmpdir do |root|
+        Env.new(
+          app_dir: root,
+          configuration: { 'foo' => 'bar', 'rmu' => 'http://doesnotexist.com', 'bar' => 'a b c', ' ' => 'a', 'b' => ' ' }
+        ).compile
+
+        env_file = File.join(root, '.profile.d', 'env.sh')
+        expect(File.file?(env_file)).to eq(true)
+
+        env_contents = File.readlines(env_file)
+        expect(env_contents.size).to eq(4)
+        expect(env_contents).to include(/export foo.*=.*"bar"/)
+        expect(env_contents).to include(%r(export rmu.*=.*\"http://doesnotexist.com\"))
+        expect(env_contents).to include(/export bar.*=.*"a b c"/)
+        expect(env_contents).to include(/export b.*=.*" "/)
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
After re-factoring the environment variables will be setup through .profile.d/env.sh script and therefore will be exposed to the entire container (instead of just the Liberty runtime).
