### PR TITLE
Fix Snaptrace template

### DIFF
--- a/lib/liberty_buildpack/jre/ibmjdk.rb
+++ b/lib/liberty_buildpack/jre/ibmjdk.rb
@@ -205,7 +205,7 @@ module LibertyBuildpack::Jre
       default_options = []
       default_options.push "-Xdump:heap:defaults:file=#{@common_paths.dump_directory}/heapdump.%Y%m%d.%H%M%S.%pid.%seq.phd"
       default_options.push "-Xdump:java:defaults:file=#{@common_paths.dump_directory}/javacore.%Y%m%d.%H%M%S.%pid.%seq.txt"
-      default_options.push "-Xdump:snap:defaults:file=#{@common_paths.dump_directory}/Snap.Y%m%d.%H%M%S.%pid.%seq.trc"
+      default_options.push "-Xdump:snap:defaults:file=#{@common_paths.dump_directory}/Snap.%Y%m%d.%H%M%S.%pid.%seq.trc"
       default_options.push '-Xdump:none'
       default_options
     end

--- a/spec/liberty_buildpack/jre/ibmjdk_spec.rb
+++ b/spec/liberty_buildpack/jre/ibmjdk_spec.rb
@@ -232,7 +232,7 @@ module LibertyBuildpack::Jre
 
          expect(released).to include('-Xdump:heap:defaults:file=' + common_paths.dump_directory + '/heapdump.%Y%m%d.%H%M%S.%pid.%seq.phd')
          expect(released).to include('-Xdump:java:defaults:file=' + common_paths.dump_directory + '/javacore.%Y%m%d.%H%M%S.%pid.%seq.txt')
-         expect(released).to include('-Xdump:snap:defaults:file=' + common_paths.dump_directory + '/Snap.Y%m%d.%H%M%S.%pid.%seq.trc')
+         expect(released).to include('-Xdump:snap:defaults:file=' + common_paths.dump_directory + '/Snap.%Y%m%d.%H%M%S.%pid.%seq.trc')
          expect(released).to include('-Xdump:none')
        end
     end


### PR DESCRIPTION
There is % missing in the Snaptrace template causing generated files to be named incorrectly.
