### PR TITLE
separate app dir paas behavior from container behavior

### DIFF
--- a/lib/liberty_buildpack/container/common_paths.rb
+++ b/lib/liberty_buildpack/container/common_paths.rb
@@ -18,42 +18,76 @@ require 'liberty_buildpack/util/heroku'
 
 module LibertyBuildpack::Container
 
-  # Representation of the common paths made available to the buildpack components. The relative_location should be
-  # updated when the execution path occurs in a path other than the default working directory so that components do
-  # not have to calculate the location of paths that are shared.
+  # CommonPaths provides buildpack components with relative paths to centralize the paths needed by components. The
+  # paths made available to the components are symbolic relative paths and are adjusted to handle path differences
+  # that occur as a result of differences in the platform container or the runtime container.
+  #
+  # Platform differences exist for an application's exeuction directory. CFv2 environments execute applications in an
+  # app root that has a the platform user directory as the parent directory.  The platform user directory may
+  # contain other data such as logs. While Heroku has a platform user directory that is used as the application
+  # directory.
+  #
+  # Container differences exist when a container's execution path isn't at the root of the application directory.
+  #
+  # Platform differences will automatically be adjusted based on the environment (and can be customized during
+  # initialization) while container differences will be adjusted if the container has set Commonpaths.relative_location.
   class CommonPaths
     include LibertyBuildpack::Util
 
+    # set by the container if needed
     attr_accessor :relative_location
 
-    # The default execution location is at the root of the current working directory.  Containers that execute
-    # in a different directory should update the relative_location.
-    def initialize
-       @relative_location = DEFAULT_LOCATION
+    # CommonPaths will account for CFv2 having an 'app' directory as the application's root directory while Heroku's
+    # application root directory will be the platform user directory.  The application  root directory will be adjusted
+    # based on the environment and can be overwritten by providing an application root directory during initialization.
+    #
+    # @param [String] app_dir  a relative path to the application's home directory
+    def initialize(app_dir = nil)
+       # relative to the application's root dir
+       @relative_location = CURRENT_DIR
+
+       # set the default app's root directory according to the environment unless an application root is provided
+       unless app_dir
+         if !Heroku.heroku?
+           app_dir = 'app'.freeze
+         else
+           app_dir = CURRENT_DIR
+         end
+       end
+
+       # for recalculating the relative location of the execution dir to the base home directory
+       # which may not necessarily be the same as the app root dir
+       @relative_app_string = valid_relative_string(app_dir)
+
+       update_relative_to_base
     end
 
     # The relative location that should be updated when the execution path occurs in the non-default working directory
+    # as determined by the container component. Setting the relative_location with this method will convert the
+    # provided relative path into one represented by symbols only.  Eg: Passing 'container/bin' will result in
+    # '../..' as the relative_location.
     #
-    # @param new_relative_location new relative_location value
+    # @param [String] the new_relative_location
     def relative_location=(new_relative_location)
-       if new_relative_location.nil? || new_relative_location.empty? || (new_relative_location.include? ' ')
-          raise 'relative_location provided to common_paths must have a valid path value'
-       end
-       @relative_location = new_relative_location
+      # Updates the application path according to the platform based on the given environment.  Heroku does not
+      # append 'app' while CloudFoundry v2 appends 'app' as the application's root in an execution environment.
+      # This allows us to adjust the common directories accordingly.
+      @relative_location = valid_relative_string(new_relative_location)
+      update_relative_to_base
     end
 
     # The expected log directory that components should store logs to.
     #
     # @return [String] the path of the log directory that components should route log files to
     def log_directory
-       File.join(@relative_location, LOG_DIRECTORY_NAME)
+       File.join(@relative_to_base, LOG_DIRECTORY_NAME)
     end
 
     # The expected dump directory that components should store dumps to.
     #
     # @return [String] the path of the dump directory that components should route dump files to
     def dump_directory
-       File.join(@relative_location, DUMP_DIRECTORY_NAME)
+       File.join(@relative_to_base, DUMP_DIRECTORY_NAME)
     end
 
     # The buildpack's diagnostics directory which contains diagnostic scripts and logs that components may
@@ -63,19 +97,34 @@ module LibertyBuildpack::Container
     #
     # @return [String] path of the buildpack diagnostics directory
     def diagnostics_directory
-       diag_location = @relative_location
-
-       # Heroku does not have an 'app' directory
-       unless Heroku.heroku?
-         diag_location = File.join(@relative_location, 'app')
-       end
-
-       File.join(diag_location, DIAGNOSTICS_DIRECTORY_NAME)
+       File.join(@relative_location, DIAGNOSTICS_DIRECTORY_NAME)
     end
 
     private
 
-    DEFAULT_LOCATION = '.'.freeze
+    def update_relative_to_base
+      if @relative_app_string
+        @relative_to_base = File.join(@relative_location, @relative_app_string)
+      else
+        @relative_to_base = @relative_location
+      end
+    end
+
+    # Validates if a pathname is valid and considred relative.  When valid, the pathname will be converted to its
+    # symbolic representation of a relative path. Ex: a relative_pathname of ./something/dir will return ../..
+    def valid_relative_string(relative_pathname)
+      if relative_pathname.nil? || relative_pathname.empty? || (relative_pathname.include? ' ')
+        raise 'relative_location provided to common_paths must be nonempty and without spaces'
+      end
+
+      begin
+        Pathname.new(CURRENT_DIR).relative_path_from(Pathname.new(relative_pathname)).to_s unless relative_pathname.eql? CURRENT_DIR
+      rescue
+        raise 'paths provided to CommonPaths must be a relative, subdirectory, and a valid Pathname'
+      end
+    end
+
+    CURRENT_DIR = '.'.freeze
     DIAGNOSTICS_DIRECTORY_NAME = LibertyBuildpack::Diagnostics::DIAGNOSTICS_DIRECTORY.freeze
     LOG_DIRECTORY_NAME = 'logs'.freeze
     DUMP_DIRECTORY_NAME = 'dumps'.freeze

--- a/lib/liberty_buildpack/container/java_main.rb
+++ b/lib/liberty_buildpack/container/java_main.rb
@@ -19,7 +19,6 @@ require 'liberty_buildpack/util/dash_case'
 require 'liberty_buildpack/util/java_main_utils'
 require 'liberty_buildpack/util'
 require 'liberty_buildpack/container/container_utils'
-require 'liberty_buildpack/container/common_paths'
 require 'fileutils'
 
 module LibertyBuildpack::Container
@@ -34,14 +33,12 @@ module LibertyBuildpack::Container
     # @option context [String] :app_dir the directory that the application exists in
     # @option context [String] :java_home the directory that acts as +JAVA_HOME+
     # @option context [Array<String>] :java_opts an array that Java options can be added to
-    # @option context [CommonPaths] :common_paths the set of paths common across components that components should reference
     # @option context [Hash] :configuration the properties provided by the user
     def initialize(context)
       @logger = LibertyBuildpack::Diagnostics::LoggerFactory.get_logger
       @app_dir = context[:app_dir]
       @java_home = context[:java_home]
       @java_opts = context[:java_opts]
-      @common_paths = context[:common_paths] || CommonPaths.new
       @configuration = context[:configuration]
     end
 
@@ -49,10 +46,7 @@ module LibertyBuildpack::Container
     #
     # @return [String] returns +Java-Main+ if the MANIFEST.MF of the application contains the Java-Main tag.
     def detect
-      if main_class
-        @common_paths.relative_location = '../'
-        ['JAR', JavaMain.to_s.dash_case]
-      end
+      main_class ? ['JAR', JavaMain.to_s.dash_case] : nil
     end
 
     # Prepares the application to run.

--- a/lib/liberty_buildpack/container/liberty.rb
+++ b/lib/liberty_buildpack/container/liberty.rb
@@ -96,7 +96,8 @@ module LibertyBuildpack::Container
     def detect
       liberty_version = Liberty.find_liberty_item(@app_dir, @configuration)[0]
       if liberty_version
-        @common_paths.relative_location = relative_directory
+        # set the relative path from '.liberty/usr/servers/defaultserver'
+        @common_paths.relative_location = File.join(LIBERTY_HOME, USR_PATH, SERVERS_PATH, DEFAULT_SERVER)
         [liberty_type, liberty_id(liberty_version)]
       end
     end
@@ -134,15 +135,6 @@ module LibertyBuildpack::Container
       jvm_options
       server_name_string = ContainerUtils.space(server_name)
       "#{create_vars_string}#{java_home_string}#{start_script_string}#{server_name_string}"
-    end
-
-    # relative location of the execution directory
-    def relative_directory
-      if Heroku.heroku?
-        '../../../..'
-      else
-        '../../../../..'
-      end
     end
 
     private

--- a/spec/liberty_buildpack/container/common_paths_spec.rb
+++ b/spec/liberty_buildpack/container/common_paths_spec.rb
@@ -26,7 +26,6 @@ module LibertyBuildpack::Container
     before do
       $stdout = StringIO.new
       $stderr = StringIO.new
-
     end
 
     after do
@@ -34,84 +33,134 @@ module LibertyBuildpack::Container
       $stderr = STDERR
     end
 
-    describe 'logs and dumps' do
-      it 'should default to the root' do
-         common_paths =  CommonPaths.new
-
-         expect(common_paths.instance_variable_get(:@relative_location)).to eq('.')
-         expect(common_paths.log_directory).to eq('./logs')
-         expect(common_paths.dump_directory).to eq('./dumps')
+    # Heroku
+    context 'For a PaaS where the app root is the same as the container user home' do
+      before do
+        ENV[HEROKU_ENV_VAR] = 'dyno'
       end
 
-      it 'should provide logs and dumps directories from specified relative location' do
-         common_paths =  CommonPaths.new
-         common_paths.relative_location = '../'
-
-         expect(common_paths.instance_variable_get(:@relative_location)).to eq('../')
-         expect(common_paths.log_directory).to eq('../logs')
-         expect(common_paths.dump_directory).to eq('../dumps')
+      after(:each) do
+        ENV[HEROKU_ENV_VAR] = nil
       end
 
-      it 'should provide logs and dumps directories from specified relative location with appended file separator' do
-         common_paths =  CommonPaths.new
-         common_paths.relative_location = '..'
+      it 'should use the current dir as the app_dir value by default' do
+        common_paths = CommonPaths.new
 
-         expect(common_paths.instance_variable_get(:@relative_location)).to eq('..')
-         expect(common_paths.log_directory).to eq('../logs')
-         expect(common_paths.dump_directory).to eq('../dumps')
+        expect(common_paths.instance_variable_get(:@relative_to_base)).to eq('.')
+        expect(common_paths.relative_location).to eq('.')
       end
 
-    end
+      # user home and app root are both the same, such as /home/dynouser is the default behavior
+      [nil, '.'].each do | test_app_root |
+        subject(:common_paths) { CommonPaths.new(test_app_root) }
 
-    describe 'buildpack diagnostics directory' do
-      context 'when app subdir exists' do
-        it 'should provide the diagnostics directory based off the app dir as a default' do
-           common_paths =  CommonPaths.new
+        # standalone java container
+        context 'with a container which executes at the root of the app dir' do
+          it 'should default to the current working directory of the app root as a relative location' do
+            expect(common_paths.relative_location).to eq('.')
+            expect(common_paths.diagnostics_directory).to eq('./.buildpack-diagnostics')
+          end
 
-           expect(common_paths.diagnostics_directory).to eq('./app/.buildpack-diagnostics')
+          it 'should return logs and dumps dir relative to the user root' do
+            expect(common_paths.log_directory).to eq('./logs')
+            expect(common_paths.dump_directory).to eq('./dumps')
+          end
         end
 
-        it 'should provide the diagnostics directory based off the appdir of a customized relatived dir' do
-           common_paths =  CommonPaths.new
-           common_paths.relative_location = '..'
-           expect(common_paths.diagnostics_directory).to eq('../app/.buildpack-diagnostics')
+        # Liberty container
+        context 'with a container that adjusts the relative dir because it executes in a subdir of the app dir' do
+          let(:new_relative_location) { 'liberty/usr/server/defaultServer' }
+
+          before do
+            common_paths.relative_location = new_relative_location
+          end
+
+          it 'should return the relative location of the container-provided path to the app root' do
+            expect(common_paths.relative_location).to eq('../../../..')
+            expect(common_paths.diagnostics_directory).to eq('../../../../.buildpack-diagnostics')
+          end
+
+          it 'should return logs and dumps dir relative to the user root adjusted with the relative location' do
+            expect(common_paths.log_directory).to eq('../../../../logs')
+            expect(common_paths.dump_directory).to eq('../../../../dumps')
+          end
+        end
+      end  # end of each test_app_root test
+    end # end of Heroku
+
+    # CFv2 - Do not stub Heroku.heroku? method to ensure the default behavior is tested
+    context 'For a PaaS that provides an app root separate from the container user root' do
+
+      it 'should use a relative path calculated from app as the app_dir value by default' do
+        common_paths = CommonPaths.new
+
+        expect(common_paths.instance_variable_get(:@relative_to_base)).to eq('./..')
+        expect(common_paths.relative_location).to eq('.')
+      end
+
+      [nil, 'app', 'app/', './app', './app/', './app/another/..'].each do | test_app_root |
+        # user root is /home/vcap while app root is /home/vcap/app
+        subject(:common_paths) { CommonPaths.new(test_app_root) }
+
+        # standalone java container
+        context 'with a container which executes at the root of the app dir' do
+          it 'should result in the default app root directory as a relative location' do
+            expect(common_paths.relative_location).to eq('.')
+            expect(common_paths.diagnostics_directory).to eq('./.buildpack-diagnostics')
+          end
+
+          it 'should return logs and dumps dir relative to the user root' do
+            expect(common_paths.log_directory).to eq('./../logs')
+            expect(common_paths.dump_directory).to eq('./../dumps')
+          end
+        end
+
+        # Liberty container
+        context 'with a container that adjusts the relative dir because it executes in a subdir of the app dir' do
+          let(:new_relative_location) { 'liberty/usr/server/defaultServer' }
+
+          before do
+            common_paths.relative_location = new_relative_location
+          end
+
+          it 'should return the relative location of the container-provided path to the app root' do
+            expect(common_paths.relative_location).to eq('../../../..')
+            expect(common_paths.diagnostics_directory).to eq('../../../../.buildpack-diagnostics')
+          end
+
+          it 'should return logs and dumps dir relative to the user root adjusted with the relative location' do
+            expect(common_paths.log_directory).to eq('../../../../../logs')
+            expect(common_paths.dump_directory).to eq('../../../../../dumps')
+          end
+        end
+      end  # end of each test_app_root test
+    end # end of CFv2 Context
+
+    describe 'invalid paths' do
+      INVALID_PATH_ERROR = 'relative_location provided to common_paths must be nonempty and without spaces'.freeze
+      INVALID_RELATIVE_PATH_ERROR = 'paths provided to CommonPaths must be a relative, subdirectory, and a valid Pathname'.freeze
+
+      ['', ' ', 'includes space'].each do | test_app_root |
+        it 'should raise an error for invalid relative_location' do
+          expect { CommonPaths.new(test_app_root) }.to raise_error(INVALID_PATH_ERROR)
         end
       end
 
-      context 'when app subdir does not exist' do
-        before do
-          ENV[HEROKU_ENV_VAR] = 'dyno'
-        end
-
-        after(:each) do
-          ENV[HEROKU_ENV_VAR] = nil
-        end
-
-        it 'should provide the diagnostics directory based off the default directory' do
-           common_paths =  CommonPaths.new
-
-           expect(common_paths.diagnostics_directory).to eq('./.buildpack-diagnostics')
-        end
-
-        it 'should provide the diagnostics directory based off the customized relatived dir' do
-           common_paths =  CommonPaths.new
-           common_paths.relative_location = '..'
-
-           expect(common_paths.diagnostics_directory).to eq('../.buildpack-diagnostics')
+      ['/', '/absolute/path', '../from/parent'].each do | test_app_root |
+        it 'should raise an error for invalid relative_location' do
+          expect { CommonPaths.new(test_app_root) }.to raise_error(INVALID_RELATIVE_PATH_ERROR)
         end
       end
 
-    end # end of buildpack diagnostic
-
-    it 'should raise an error for invalid relative_location' do
-      INVALID_PATH_ERROR = 'relative_location provided to common_paths must have a valid path value'.freeze
-      common_paths =  CommonPaths.new
-
-      expect { common_paths.relative_location = nil }.to raise_error(INVALID_PATH_ERROR)
-      expect { common_paths.relative_location = '' }.to raise_error(INVALID_PATH_ERROR)
-      expect { common_paths.relative_location = ' ' }.to raise_error(INVALID_PATH_ERROR)
-    end
+      [nil, '', ' '].each do | test_relative_location |
+        it 'should raise an error for invalid relative_location' do
+          common_paths =  CommonPaths.new
+          expect { common_paths.relative_location = test_relative_location }.to raise_error(INVALID_PATH_ERROR)
+        end
+      end
+    end # end of invalid paths tests
 
   end
 
 end
+

--- a/spec/liberty_buildpack/container/java_main_spec.rb
+++ b/spec/liberty_buildpack/container/java_main_spec.rb
@@ -59,28 +59,6 @@ module LibertyBuildpack::Container
       it 'should not detect without manifest' do
         expect(detected).to be_nil
       end
-
-      describe 'the relative location returned by common paths after detect gets invoked' do
-        subject(:relative_location) do |example|
-          java_main = JavaMain.new(context)
-          java_main.detect
-          actual_common_paths = java_main.instance_variable_get(:@common_paths)
-          actual_common_paths.instance_variable_get(:@relative_location)
-        end
-
-        it 'should update the common_paths provided by the buildpack to include the Standalone Java container path',
-           common_paths: CommonPaths.new,
-           configuration: { 'java_main_class' => 'java-main' } do
-
-          expect(relative_location).to eq('../')
-        end
-
-        it 'should result with Java Standalone path when the common_paths is not provided in its context',
-           configuration: { 'java_main_class' => 'java-main' } do
-
-          expect(relative_location).to eq('../')
-        end
-      end
     end
 
     describe 'compile' do

--- a/spec/liberty_buildpack/jre/ibmjdk_spec.rb
+++ b/spec/liberty_buildpack/jre/ibmjdk_spec.rb
@@ -271,7 +271,7 @@ module LibertyBuildpack::Jre
             license_ids: {}
         ).release
 
-        expect(java_opts).to include("-Xdump:tool:events=systhrow,filter=java/lang/OutOfMemoryError,request=serial+exclusive,exec=./app/#{LibertyBuildpack::Diagnostics::DIAGNOSTICS_DIRECTORY}/#{IBMJdk::KILLJAVA_FILE_NAME}")
+        expect(java_opts).to include("-Xdump:tool:events=systhrow,filter=java/lang/OutOfMemoryError,request=serial+exclusive,exec=./#{LibertyBuildpack::Diagnostics::DIAGNOSTICS_DIRECTORY}/#{IBMJdk::KILLJAVA_FILE_NAME}")
       end
     end
 

--- a/spec/liberty_buildpack/jre/openjdk_spec.rb
+++ b/spec/liberty_buildpack/jre/openjdk_spec.rb
@@ -140,7 +140,7 @@ module LibertyBuildpack::Jre
             license_ids: {}
         ).release
 
-        expect(java_opts).to include("-XX:OnOutOfMemoryError=./app/#{LibertyBuildpack::Diagnostics::DIAGNOSTICS_DIRECTORY}/#{OpenJdk::KILLJAVA_FILE_NAME}")
+        expect(java_opts).to include("-XX:OnOutOfMemoryError=./#{LibertyBuildpack::Diagnostics::DIAGNOSTICS_DIRECTORY}/#{OpenJdk::KILLJAVA_FILE_NAME}")
       end
     end
 


### PR DESCRIPTION
Addresses a problem where the logs and dumps directory returned by CommonPaths will be incorrect in the Heroku environment for a standalone java application.  With this updated, CommonPaths has been updated to separate platform container from runtime container behavior differences such that multiple environments and containers can be better handled.
