### PR TITLE
Mask credentials

### DIFF
--- a/lib/liberty_buildpack/buildpack.rb
+++ b/lib/liberty_buildpack/buildpack.rb
@@ -208,7 +208,11 @@ module LibertyBuildpack
     end
 
     def self.log_debug_data(logger)
-      logger.debug { "Environment Variables: #{ENV.to_hash}" }
+      safe_env = ENV.to_hash
+      if safe_env.has_key? 'VCAP_SERVICES'
+        safe_env.merge!({ 'VCAP_SERVICES' => LibertyBuildpack::Util.safe_vcap_services(safe_env['VCAP_SERVICES']) })
+      end
+      logger.debug { "Environment Variables: #{safe_env}" }
 
       # Log information about the buildpack's git repository to enable stale forks to be spotted.
       # Call the debug method passing a parameter rather than a block so that, should the git command

--- a/lib/liberty_buildpack/container/services_manager.rb
+++ b/lib/liberty_buildpack/container/services_manager.rb
@@ -20,6 +20,7 @@ require 'fileutils'
 require 'set'
 require 'liberty_buildpack/container'
 require 'liberty_buildpack/container/install_components'
+require 'liberty_buildpack/util'
 require 'liberty_buildpack/util/constantize'
 require 'liberty_buildpack/util/application_cache'
 require 'liberty_buildpack/util/format_duration'
@@ -32,7 +33,7 @@ module LibertyBuildpack::Container
 
     def initialize(vcap_services, server_dir, opt_out_string)
       @logger = LibertyBuildpack::Diagnostics::LoggerFactory.get_logger
-      @logger.debug("init: server dir is #{server_dir}, vcap_services is #{vcap_services} and opt_out is #{opt_out_string}")
+      @logger.debug("init: server dir is #{server_dir}, vcap_services is #{LibertyBuildpack::Util.safe_vcap_services(vcap_services)} and opt_out is #{opt_out_string}")
       @opt_out = parse_opt_out(opt_out_string)
       FileUtils.mkdir_p(server_dir)
       # The collection of service instances that require full autoconfig
@@ -258,14 +259,14 @@ module LibertyBuildpack::Container
       runtime_vars_doc = REXML::Document.new('<server></server>')
       unless vcap_services.nil?
         vcap_services.each do |service_type, service_data|
-          @logger.debug("processing service type #{service_type} and data #{service_data}")
+          @logger.debug("processing service type #{service_type} and data #{LibertyBuildpack::Util.safe_vcap_services(service_data)}")
           process_service_type(runtime_vars_doc.root, service_type, service_data)
         end
       end
       runtime_vars = File.join(server_dir, 'runtime-vars.xml')
       LibertyBuildpack::Util::XmlUtils.write_formatted_xml_file(runtime_vars_doc, runtime_vars)
       @logger.debug("runtime-vars file is #{runtime_vars}")
-      @logger.debug("runtime vars contents is #{File.readlines(runtime_vars)}")
+      @logger.debug("runtime vars contents is #{LibertyBuildpack::Util.safe_credential_properties(File.readlines(runtime_vars))}")
     end
 
     #------------------------------------------------------

--- a/lib/liberty_buildpack/util.rb
+++ b/lib/liberty_buildpack/util.rb
@@ -45,4 +45,19 @@ module LibertyBuildpack::Util
     service
   end
 
+  # Get services as either hash or string and return as a string with
+  # credentials info masked out as PRIVATE DATA HIDDEN string
+  #
+  # @return [String] returns masked vcap_services string
+  def self.safe_vcap_services(vcap_services)
+    vcap_services.to_s.gsub(/(\"credentials\".+?){.*?}/, '\\1["PRIVATE DATA HIDDEN"]')
+  end
+
+  # Get services as either array or a string of lines from runtime_vars.xml
+  # and mask cloud.services.*.connection.* values out as PRIVATE DATA HIDDEN
+  #
+  # @return [String] returns masked runtime_vars.xml content
+  def self.safe_credential_properties(property)
+    property.to_s.gsub(/(<variable\s+name='cloud\.services\.[^']*\.connection\.[^']*'\s+value=').*?('\s*\/>)/, '\\1[PRIVATE DATA HIDDEN]\\2')
+  end
 end


### PR DESCRIPTION
The change is to make sure service credentials information is not stored in log files even when debug level is turned on.
