### PR TITLE
Hide credentials specified in VCAP_SERVICES

### DIFF
--- a/lib/liberty_buildpack/util.rb
+++ b/lib/liberty_buildpack/util.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 require 'liberty_buildpack'
+require 'liberty_buildpack/util/heroku'
+require 'json'
 
 # A module encapsulating all of the utility code for the Java buildpack
 module LibertyBuildpack::Util
@@ -45,4 +47,64 @@ module LibertyBuildpack::Util
     service
   end
 
+  # Get services as either hash or string and return as the same object but
+  # with credentials info masked out as PRIVATE DATA HIDDEN string
+  #
+  # @return [Object] returns object with credentials info masked out
+  def self.safe_vcap_services(vcap_services)
+    if vcap_services.class == String && !vcap_services.strip.empty?
+      begin
+        safe_hash = JSON.load(vcap_services)
+      rescue JSON::ParserError
+        return vcap_services
+      end
+    elsif vcap_services.class == Hash
+      safe_hash = vcap_services.clone
+    else
+      return vcap_services
+    end
+    safe_hash.each { |type, data| safe_hash[type] = safe_service_data(data) }
+    if vcap_services.class == String
+      safe_hash.to_json
+    else
+      safe_hash
+    end
+  end
+
+  # Get array of service instances and mask 'credential' entry in each
+  # of them with PRIVATE DATA HIDDEN
+  #
+  # @return [Array] returns array of masked out instances
+  def self.safe_service_data(vcap_service_data)
+    return vcap_service_data if vcap_service_data.class != Array
+    safe_array = []
+    vcap_service_data.each do |instance|
+      safe_instance = instance.clone
+      if safe_instance.class == Hash && safe_instance.has_key?('credentials')
+        safe_instance['credentials'] = ['PRIVATE DATA HIDDEN']
+      end
+      safe_array << safe_instance
+    end
+    safe_array
+  end
+
+  # Get services as either array or a string of lines from runtime_vars.xml
+  # and mask cloud.services.*.connection.* values out as PRIVATE DATA HIDDEN
+  #
+  # @return [String] returns masked runtime_vars.xml content
+  def self.safe_credential_properties(property)
+    property.to_s.gsub(/(<variable\s+name='cloud\.services\.[^.]*\.connection\..*?'\s+value=').*?('\s*\/>)/, '\\1[PRIVATE DATA HIDDEN]\\2')
+  end
+
+  # Get copy of ENV as a hash and mask in place all Heroku specific
+  # environment variables containing 'credentials' information
+  #
+  # @return [Hash] return env back with the data
+  def self.safe_heroku_env!(env)
+    env.each do |key, value|
+      if key.end_with?(Heroku::URL_SUFFIX) || key.end_with?(Heroku::URI_SUFFIX)
+        env[key] = '[PRIVATE DATA HIDDEN]'
+      end
+    end
+  end
 end

--- a/lib/liberty_buildpack/util/heroku.rb
+++ b/lib/liberty_buildpack/util/heroku.rb
@@ -59,7 +59,7 @@ module LibertyBuildpack::Util
             type = key
             service = {}
             service['name'] = service_name_map[key] || generate_name(key)
-            service['credentials'] = create_default_credentials(value)
+            service['credentials'] = create_default_credentials(key, value)
           end
 
           vcap_services[type] = [service]
@@ -110,7 +110,7 @@ module LibertyBuildpack::Util
       [key, service]
     end
 
-    def create_default_credentials(value)
+    def create_default_credentials(key, value)
       credentials = {}
       begin
         uri = URI.parse(value)
@@ -120,7 +120,7 @@ module LibertyBuildpack::Util
         credentials['password'] = uri.password unless uri.password.nil?
         credentials['name'] = uri.path[1..-1]  unless uri.path[1..-1].nil?
       rescue URI::InvalidURIError
-        @logger.debug("unable to parse #{value}")
+        @logger.debug("unable to parse #{key}")
       end
       credentials['uri'] = credentials['url'] = value
       credentials

--- a/spec/liberty_buildpack/util_spec.rb
+++ b/spec/liberty_buildpack/util_spec.rb
@@ -1,0 +1,156 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2013-2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'liberty_buildpack/util'
+
+module LibertyBuildpack
+
+  describe Util do
+
+    describe 'safe_vcap_services' do
+
+      it 'should not fail on nil' do
+        expect(LibertyBuildpack::Util.safe_vcap_services(nil)).to eq(nil)
+      end
+
+      it 'should not fail on empty objects' do
+        expect(LibertyBuildpack::Util.safe_vcap_services('')).to eq('')
+        expect(LibertyBuildpack::Util.safe_vcap_services({})).to eq({})
+        expect(LibertyBuildpack::Util.safe_vcap_services([])).to eq([])
+      end
+
+      it 'should not fail on none JSON strings' do
+        expect(LibertyBuildpack::Util.safe_vcap_services('wrong')).to eq('wrong')
+      end
+
+      it 'should not fail on none-empty arrays' do
+        expect(LibertyBuildpack::Util.safe_vcap_services(['one'])).to eq(['one'])
+      end
+
+      it 'should not fail on maps containing nil as value' do
+        expect(LibertyBuildpack::Util.safe_vcap_services({ 'one' => nil })).to eq({ 'one' => nil })
+        expect(LibertyBuildpack::Util.safe_vcap_services('{"one": null}')).to eq('{"one":null}')
+      end
+
+      it 'should mask "credential" entries' do
+        expect(LibertyBuildpack::Util.safe_vcap_services({ 'database' => [{ 'credentials' => { 'identity' => 'VERY SECRET PHRASE' } }] })).to eq({ 'database' => [{ 'credentials' => ['PRIVATE DATA HIDDEN'] }] })
+      end
+
+      it 'should not mask than than "credential" entries' do
+        expect(LibertyBuildpack::Util.safe_vcap_services({ 'database' => [{ 'name' =>  'PLAIN NAME' }] })).to eq({ 'database' => [{ 'name' => 'PLAIN NAME' }] })
+      end
+
+      it 'should not alter input variable' do
+        input = { 'database' => [{ 'credentials' => { 'identity' => 'VERY SECRET PHRASE' } }] }
+        output = LibertyBuildpack::Util.safe_vcap_services(input)
+        expect(output).not_to eq(input)
+      end
+    end
+
+    describe 'safe_service_data' do
+
+      it 'should not fail on nil' do
+        expect(LibertyBuildpack::Util.safe_service_data(nil)).to eq(nil)
+      end
+
+      it 'should not fail on empty objects' do
+        expect(LibertyBuildpack::Util.safe_service_data('')).to eq('')
+        expect(LibertyBuildpack::Util.safe_service_data([])).to eq([])
+        expect(LibertyBuildpack::Util.safe_service_data({})).to eq({})
+      end
+
+      it 'should not fail on non map array elements' do
+        expect(LibertyBuildpack::Util.safe_service_data(['one'])).to eq(['one'])
+        expect(LibertyBuildpack::Util.safe_service_data([['one']])).to eq([['one']])
+      end
+
+      it 'should mask "credential" entries' do
+        expect(LibertyBuildpack::Util.safe_service_data([{ 'credentials' => 'VERY SECRET PHRASE' }])).to eq([{ 'credentials' => ['PRIVATE DATA HIDDEN'] }])
+      end
+
+      it 'should not mask other than "credential" entries' do
+        expect(LibertyBuildpack::Util.safe_service_data([{ 'data' => 'PLAIN DATA' }])).to eq([{ 'data' => 'PLAIN DATA' }])
+      end
+
+      it 'hould not alter input variable' do
+        input = [{ 'credentials' => 'VERY SECRET PHRASE' }]
+        output = LibertyBuildpack::Util.safe_service_data(input)
+        expect(output).not_to eq(input)
+      end
+
+    end
+
+    describe 'safe_credential_properties' do
+      it 'should not fail on nil' do
+        expect(LibertyBuildpack::Util.safe_credential_properties(nil)).to eq('')
+      end
+
+      it 'should not fail on empty string' do
+        expect(LibertyBuildpack::Util.safe_credential_properties('')).to eq('')
+      end
+
+      it 'should mask cloud.services.*.connection.* values' do
+        expect(LibertyBuildpack::Util.safe_credential_properties("<variable name='cloud.services.data.connection.identity' value='VERY SECRET PHRASE'/>")).to eq("<variable name='cloud.services.data.connection.identity' value='[PRIVATE DATA HIDDEN]'/>")
+      end
+
+      it 'should not mask other than cloud.services.*.connection.* entries' do
+        expect(LibertyBuildpack::Util.safe_credential_properties("<variable name='cloud.services.data.name' value='PLAIN NAME'/>")).to eq("<variable name='cloud.services.data.name' value='PLAIN NAME'/>")
+      end
+
+      it 'should mask only cloud.services.*.connection.* entries' do
+        input = [
+          "<variable name='cloud.services.data.name' value='PLAIN NAME'/>",
+          "<variable name='cloud.services.data.connection.identity' value='VERY SECRET PHRASE'/>",
+          "<variable name='cloud.services.data.version' value='PLAIN VERSION'/>"
+       ]
+
+        expected = [
+          input[0],
+          "<variable name='cloud.services.data.connection.identity' value='[PRIVATE DATA HIDDEN]'/>",
+          input[2]
+        ]
+
+        expect(LibertyBuildpack::Util.safe_credential_properties(input)).to eq(expected.to_s)
+      end
+
+      it 'should not alter input variable' do
+        input = "<variable name='cloud.services.data.connection.identity' value='VERY SECRET PHRASE'/>"
+        output = LibertyBuildpack::Util.safe_credential_properties(input)
+        expect(output).not_to eq(input)
+      end
+
+    end
+
+    describe 'safe_heroku_env' do
+
+      it 'should mask all variables ending in _URI and _URL' do
+        safe_env = { 'SECRET_URL' => 'secret URL', 'SECRET_URI' => 'secret URI' }
+        LibertyBuildpack::Util.safe_heroku_env!(safe_env)
+        expect(safe_env).to eq({ 'SECRET_URL' => '[PRIVATE DATA HIDDEN]', 'SECRET_URI' => '[PRIVATE DATA HIDDEN]' })
+      end
+
+      it 'should not mask other variables than the one ending in _URI and _URL' do
+        safe_env = { 'GOOD_VAR' => 'good data' }
+        LibertyBuildpack::Util.safe_heroku_env!(safe_env)
+        expect(safe_env).to eq({ 'GOOD_VAR' => 'good data' })
+      end
+
+    end
+
+  end
+
+end

--- a/spec/logging_helper.rb
+++ b/spec/logging_helper.rb
@@ -38,6 +38,7 @@ shared_context 'logging_helper' do
     $DEBUG = example.metadata[:debug]
     $VERBOSE = example.metadata[:verbose]
 
+    LibertyBuildpack::Diagnostics::LoggerFactory.send :close # suppress warnings
     LibertyBuildpack::Diagnostics::LoggerFactory.create_logger app_dir
   end
 


### PR DESCRIPTION
This is request addressing the reviewers comments. 1. take into account that credentials can be of any type 2. Checked the extra files and they do not expose VCAP_SERVICES info passed to buildpack from the fabric.
