### PR TITLE
improvement for rspec testing during TDD dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.rspec-local
 .DS_Store
 .idea
 .yardoc

--- a/Rakefile
+++ b/Rakefile
@@ -18,9 +18,6 @@ RSpec::Core::RakeTask.new(:spec) do |t|
   t.rspec_opts = '--tty' if ENV.has_key? 'RAKE_FORCE_COLOR'
 end
 
-require 'ci/reporter/rake/rspec'
-task :spec => "ci:setup:rspec"
-
 require 'yard'
 YARD::Rake::YardocTask.new do |t|
   t.options = ['--no-stats']
@@ -96,7 +93,7 @@ task :package, [:zipfile, :hosts, :version] do |t, args|
 
     bc = BuildpackCache.new(File.join(dest, 'admin_cache'))
     # Collect all remote content using all config files
-    configs = bc.collect_configs nil, cache_hosts 
+    configs = bc.collect_configs nil, cache_hosts
     bc.download_cache(configs)
     # Fix file permissions
     system("find #{dest} -type f -exec chmod a+r {} \\;")

--- a/spec/buildpack_cache_helper.rb
+++ b/spec/buildpack_cache_helper.rb
@@ -27,9 +27,11 @@ shared_context 'buildpack_cache_helper' do
   let(:buildpack_cache_dir) { app_dir }
 
   let(:java_buildpack_cache_dir) { buildpack_cache_dir + 'java-buildpack' }
+  let(:ibm_liberty_buildpack_cache_dir) { buildpack_cache_dir + 'ibm-liberty-buildpack' }
 
   before do
     FileUtils.mkdir_p java_buildpack_cache_dir
+    FileUtils.mkdir_p ibm_liberty_buildpack_cache_dir
     ENV['BUILDPACK_CACHE'] = buildpack_cache_dir.to_s
   end
 

--- a/spec/component_helper.rb
+++ b/spec/component_helper.rb
@@ -15,12 +15,14 @@
 # limitations under the License.
 
 require 'spec_helper'
+require 'logging_helper'
 require 'application_helper'
 require 'console_helper'
 
 shared_context 'component_helper' do
   include_context 'application_helper'
   include_context 'console_helper'
+  include_context 'logging_helper'
 
   let(:component) { described_class.new context }
 

--- a/spec/liberty_buildpack/container/common_paths_spec.rb
+++ b/spec/liberty_buildpack/container/common_paths_spec.rb
@@ -23,16 +23,6 @@ module LibertyBuildpack::Container
 
     HEROKU_ENV_VAR = 'DYNO'.freeze
 
-    before do
-      $stdout = StringIO.new
-      $stderr = StringIO.new
-    end
-
-    after do
-      $stdout = STDOUT
-      $stderr = STDERR
-    end
-
     # Heroku
     context 'For a PaaS where the app root is the same as the container user home' do
       before do

--- a/spec/liberty_buildpack/container/feature_manager_spec.rb
+++ b/spec/liberty_buildpack/container/feature_manager_spec.rb
@@ -17,11 +17,13 @@
 require 'fileutils'
 require 'liberty_buildpack/container/feature_manager'
 require 'spec_helper'
+require 'logging_helper'
 require 'tmpdir'
 
 module LibertyBuildpack::Container
 
   describe FeatureManager do
+    include_context 'logging_helper'
 
     FEATURE_REPOSITORY_FIXTURE_DIR = 'spec/fixtures/liberty_feature_repository'.freeze
 

--- a/spec/liberty_buildpack/container/install_components_spec.rb
+++ b/spec/liberty_buildpack/container/install_components_spec.rb
@@ -21,16 +21,6 @@ module LibertyBuildpack::Container
 
   describe InstallComponents do
 
-    before do
-      $stdout = StringIO.new
-      $stderr = StringIO.new
-    end
-
-    after do
-      $stdout = STDOUT
-      $stderr = STDERR
-    end
-
     describe 'zip' do
 
       it 'add zip' do

--- a/spec/liberty_buildpack/container/liberty_spec.rb
+++ b/spec/liberty_buildpack/container/liberty_spec.rb
@@ -15,12 +15,14 @@
 # the License.
 
 require 'spec_helper'
+require 'logging_helper'
 require 'liberty_buildpack/container/liberty'
 require 'liberty_buildpack/container/container_utils'
 
 module LibertyBuildpack::Container
 
   describe Liberty do
+    include_context 'logging_helper'    # logging_helper only for now
 
     LIBERTY_VERSION = LibertyBuildpack::Util::TokenizedVersion.new('8.5.5')
     LIBERTY_SINGLE_DOWNLOAD_URI = 'test-liberty-uri.tar.gz'.freeze # end of URI (here ".tar.gz") is significant in liberty container code
@@ -31,15 +33,8 @@ module LibertyBuildpack::Container
     let(:component_index) { double('ComponentIndex') }
 
     before do
-      $stdout = StringIO.new
-      $stderr = StringIO.new
       # return license file by default
       application_cache.stub(:get).and_yield(File.open('spec/fixtures/license.html'))
-    end
-
-    after do
-      $stdout = STDOUT
-      $stderr = STDERR
     end
 
     describe 'prepare applications' do

--- a/spec/liberty_buildpack/framework/env_spec.rb
+++ b/spec/liberty_buildpack/framework/env_spec.rb
@@ -15,11 +15,13 @@
 # limitations under the License.
 
 require 'spec_helper'
+require 'logging_helper'
 require 'liberty_buildpack/framework/env'
 
 module LibertyBuildpack::Framework
 
   describe Env do
+    include_context 'logging_helper'
 
     it 'should detect with env configuration' do
       detected = Env.new(

--- a/spec/liberty_buildpack/framework/spring_auto_reconfiguration_spec.rb
+++ b/spec/liberty_buildpack/framework/spring_auto_reconfiguration_spec.rb
@@ -15,11 +15,13 @@
 # limitations under the License.
 
 require 'spec_helper'
+require 'logging_helper'
 require 'liberty_buildpack/framework/spring_auto_reconfiguration'
 
 module LibertyBuildpack::Framework
 
   describe SpringAutoReconfiguration do
+    include_context 'logging_helper'
 
     SPRING_AUTO_RECONFIGURATION_VERSION = LibertyBuildpack::Util::TokenizedVersion.new('0.6.8')
 
@@ -27,16 +29,6 @@ module LibertyBuildpack::Framework
 
     let(:application_cache) { double('ApplicationCache') }
     let(:web_xml_modifier) { double('WebXmlModifier') }
-
-    before do
-      $stdout = StringIO.new
-      $stderr = StringIO.new
-    end
-
-    after do
-      $stdout = STDOUT
-      $stderr = STDERR
-    end
 
     it 'should detect with Spring JAR in WEB-INF' do
       LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item).and_return(SPRING_AUTO_RECONFIGURATION_DETAILS)

--- a/spec/liberty_buildpack/jre/openjdk_spec.rb
+++ b/spec/liberty_buildpack/jre/openjdk_spec.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 require 'spec_helper'
+require 'logging_helper'
 require 'fileutils'
 require 'liberty_buildpack/jre/openjdk'
 require 'liberty_buildpack/container/common_paths'
@@ -22,6 +23,7 @@ require 'liberty_buildpack/container/common_paths'
 module LibertyBuildpack::Jre
 
   describe OpenJdk do
+    include_context 'logging_helper'
 
     OPENJDK_DETAILS_PRE_8 = [LibertyBuildpack::Util::TokenizedVersion.new('1.7.0'), 'test-uri']
     OPENJDK_DETAILS_POST_8 = [LibertyBuildpack::Util::TokenizedVersion.new('1.8.0'), 'test-uri']
@@ -31,13 +33,6 @@ module LibertyBuildpack::Jre
 
     before do
       allow(LibertyBuildpack::Jre::WeightBalancingMemoryHeuristic).to receive(:new).and_return(memory_heuristic)
-      $stdout = StringIO.new
-      $stderr = StringIO.new
-    end
-
-    after do
-      $stdout = STDOUT
-      $stderr = STDERR
     end
 
     it 'should detect with id of openjdk-<version>' do

--- a/spec/liberty_buildpack/services/mongo_spec.rb
+++ b/spec/liberty_buildpack/services/mongo_spec.rb
@@ -15,6 +15,7 @@
 # the License.
 
 require 'spec_helper'
+require 'logging_helper'
 require 'liberty_buildpack/container/services_manager'
 require 'liberty_buildpack/services/mongo'
 require 'liberty_buildpack/util/heroku'
@@ -22,6 +23,7 @@ require 'liberty_buildpack/util/heroku'
 module LibertyBuildpack::Services
 
   describe 'MongoDB' do
+    include_context 'logging_helper'
 
     #----------------
     # Helper method to check an xml file agains expected results.

--- a/spec/liberty_buildpack/services/mysql_spec.rb
+++ b/spec/liberty_buildpack/services/mysql_spec.rb
@@ -15,12 +15,14 @@
 # the License.
 
 require 'spec_helper'
+require 'logging_helper'
 require 'liberty_buildpack/container/services_manager'
 require 'liberty_buildpack/util/heroku'
 
 module LibertyBuildpack::Services
 
   describe 'MySQL' do
+    include_context 'logging_helper'
 
     #----------------
     # Helper method to check an xml file agains expected results.

--- a/spec/liberty_buildpack/services/postgresql_spec.rb
+++ b/spec/liberty_buildpack/services/postgresql_spec.rb
@@ -15,12 +15,14 @@
 # the License.
 
 require 'spec_helper'
+require 'logging_helper'
 require 'liberty_buildpack/container/services_manager'
 require 'liberty_buildpack/util/heroku'
 
 module LibertyBuildpack::Services
 
   describe 'PostgreSQL' do
+    include_context 'logging_helper'
 
     #----------------
     # Helper method to check an xml file agains expected results.

--- a/spec/liberty_buildpack/services/utils_spec.rb
+++ b/spec/liberty_buildpack/services/utils_spec.rb
@@ -15,11 +15,13 @@
 # the License.
 
 require 'spec_helper'
+require 'logging_helper'
 require 'rexml/document'
 require 'liberty_buildpack/services/utils'
 
 module LibertyBuildpack::Services
   describe Utils do
+    include_context 'logging_helper'
 
     #----------------
     # Helper method to check an xml file agains expected results.

--- a/spec/logging_helper.rb
+++ b/spec/logging_helper.rb
@@ -38,11 +38,15 @@ shared_context 'logging_helper' do
     $DEBUG = example.metadata[:debug]
     $VERBOSE = example.metadata[:verbose]
 
-    LibertyBuildpack::Diagnostics::LoggerFactory.send :close # suppress warnings
-    LibertyBuildpack::Diagnostics::LoggerFactory.create_logger app_dir
+    LibertyBuildpack::Diagnostics::LoggerFactory.send :close
+    diagnostics_directory = LibertyBuildpack::Diagnostics.get_diagnostic_directory(app_dir)
+    FileUtils.rm_rf diagnostics_directory
+
+    raise 'Failed to create logger' if LibertyBuildpack::Diagnostics::LoggerFactory.create_logger(app_dir).nil?
   end
 
   after do
+    LibertyBuildpack::Diagnostics::LoggerFactory.send :close
     FileUtils.rm_rf LibertyBuildpack::Diagnostics.get_diagnostic_directory app_dir
 
     ENV['JBP_LOG_LEVEL'] = previous_log_level

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,18 +36,4 @@ RSpec.configure do |config|
     c.syntax = [:should, :expect]
   end
   config.filter_run :focus
-  # Ensure a logger exists for any class under test that needs one.
-  config.before(:all) do
-    LibertyBuildpack::Diagnostics::LoggerFactory.send :close
-    diagnostics_directory = LibertyBuildpack::Diagnostics.get_diagnostic_directory(Dir.tmpdir)
-    FileUtils.rm_rf diagnostics_directory
-    raise 'Failed to create logger' if LibertyBuildpack::Diagnostics::LoggerFactory.create_logger(Dir.tmpdir).nil?
-  end
-
-  config.after(:all) do
-    LibertyBuildpack::Diagnostics::LoggerFactory.send :close
-    diagnostics_directory = LibertyBuildpack::Diagnostics.get_diagnostic_directory(Dir.tmpdir)
-    FileUtils.rm_rf diagnostics_directory
-  end
-
 end


### PR DESCRIPTION
Changes to help improve running of rspec tests during dev mode:
1.  cleanup of lots of output being displayed to the console, which made the rake summary hard to read. 
2.  resolve formatter warnings that resulted from prior rspec2 to rspec3 library update

Tip:  When debugging/troubleshooting a failed test and display of output is needed, output can be displayed by setting metadata of the test with show_output: 'true' and log_level: 'DEBUG'.
