### PR TITLE
ignore local rspec configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.rspec-local
 .DS_Store
 .idea
 .yardoc


### PR DESCRIPTION
Update to ignore local rspec config so that a .local-rspec config can be locally customized for faster local runs. A sample recommended local config during dev to fail quickly and exclude integration tests such as spec/bin/compile_spec.rb (which takes a while as it downloads artifacts):

--fail-fast
--tag ~integration
