### PR TITLE
allow for user invoked dumps

### DIFF
--- a/lib/liberty_buildpack/jre/ibmjdk.rb
+++ b/lib/liberty_buildpack/jre/ibmjdk.rb
@@ -207,6 +207,7 @@ module LibertyBuildpack::Jre
       default_options.push "-Xdump:heap:defaults:file=#{@common_paths.dump_directory}/heapdump.%Y%m%d.%H%M%S.%pid.%seq.phd"
       default_options.push "-Xdump:java:defaults:file=#{@common_paths.dump_directory}/javacore.%Y%m%d.%H%M%S.%pid.%seq.txt"
       default_options.push "-Xdump:snap:defaults:file=#{@common_paths.dump_directory}/Snap.%Y%m%d.%H%M%S.%pid.%seq.trc"
+      default_options.push '-Xdump:heap+java+snap:events=user'
       default_options
     end
 

--- a/spec/liberty_buildpack/jre/ibmjdk_spec.rb
+++ b/spec/liberty_buildpack/jre/ibmjdk_spec.rb
@@ -144,11 +144,11 @@ module LibertyBuildpack::Jre
         subject(:released) { IBMJdk.new(context).release }
 
         it 'should add default dump options that output data to the common dumps directory, if enabled' do
-
-          expect(released).to include('-Xdump:heap:defaults:file=./../dumps/heapdump.%Y%m%d.%H%M%S.%pid.%seq.phd')
-          expect(released).to include('-Xdump:java:defaults:file=./../dumps/javacore.%Y%m%d.%H%M%S.%pid.%seq.txt')
-          expect(released).to include('-Xdump:snap:defaults:file=./../dumps/Snap.%Y%m%d.%H%M%S.%pid.%seq.trc')
-          expect(released).to include('-Xdump:none')
+          expect(released).to include('-Xdump:none',
+                                      '-Xdump:heap:defaults:file=./../dumps/heapdump.%Y%m%d.%H%M%S.%pid.%seq.phd',
+                                      '-Xdump:java:defaults:file=./../dumps/javacore.%Y%m%d.%H%M%S.%pid.%seq.txt',
+                                      '-Xdump:snap:defaults:file=./../dumps/Snap.%Y%m%d.%H%M%S.%pid.%seq.trc',
+                                      '-Xdump:heap+java+snap:events=user')
         end
 
         it 'should add extra memory options when a memory limit is set' do


### PR DESCRIPTION
This change allows for user-invoked jvm dumps to be triggered in environments where operators have access to the container to invoke dumps through commands such as "kill -3 <pid>".