### PR TITLE
raise error for multiple matches

### DIFF
--- a/docs/framework-new-relic-agent.md
+++ b/docs/framework-new-relic-agent.md
@@ -3,9 +3,8 @@ The New Relic Agent Framework causes an application to be automatically configur
 
 <table>
   <tr>
-    <td><strong>Detection Criterion</strong></td><td>Existence of a New Relic service is defined as the <a href="http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES"><code>VCAP_SERVICES</code></a> payload containing at least one of the following:
+    <td><strong>Detection Criterion</strong></td><td>Existence of a single New Relic service is defined as the <a href="http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES"><code>VCAP_SERVICES</code></a> payload containing at least one of the following:
       <ul>
-        <li>service key name of <code>newrelic</code>.</li>
         <li>name that has the substring <code>newrelic</code>. <strong>Note: </strong> This is only applicable to user-provided services</li>
         <li>label that has the substring <code>newrelic</code>.</li>
         <li>tags that have the substring <code>newrelic</code>.</li>

--- a/lib/liberty_buildpack/framework/new_relic_agent.rb
+++ b/lib/liberty_buildpack/framework/new_relic_agent.rb
@@ -114,37 +114,13 @@ module LibertyBuildpack::Framework
     NR_HOME_DIR = '.new_relic_agent'.freeze
 
     #-----------------------------------------------------------------------------------------
-    # Determines if the New Relic service is included in VCAP_SERVICES. First, the service type
-    # will be checked as a quick test for an exact match.  If the service type value does not match
-    # the New Relic service name, then the New Relic service name will be used as a regular
-    # expression by the services utility that checks all the services that have either a name,
-    # label, or a tag that includes the service name as a substring.
+    # Determines if the New Relic service is included in VCAP_SERVICES based on whether the
+    # service entry has valid entries.
     #
     # @return [Boolean]  true if the app is bound to a new relic service
     #------------------------------------------------------------------------------------------
     def nr_service_exist?
-      exact_service_type_match? || service_manager_match?
-    end
-
-    #-----------------------------------------------------------------------------------------
-    # Use the New Relic service name as a filter for the service manager to process all the
-    # VCAP_SERVICES services and return true for the first service that contains other valid keys
-    # with values that match the new relic filter.
-    #
-    # @return [Boolean]  true if the app is bound to a new relic service based on the service manager criteria
-    #------------------------------------------------------------------------------------------
-    def service_manager_match?
       @services.one_service?(NR_SERVICE_NAME, LICENSE_KEY)
-    end
-
-    #-----------------------------------------------------------------------------------------
-    # Return true if VCAP_SERVICES contains a service key name that matches exactly with the
-    # the new relic service name. A quick test to avoid processing all the services.
-    #
-    # @return [Boolean]  true if the service type name is an exact match to newrelic's service name
-    #------------------------------------------------------------------------------------------
-    def exact_service_type_match?
-      !@vcap_services.nil? && !@vcap_services[NR_SERVICE_NAME].nil? && !@vcap_services[NR_SERVICE_NAME].empty?
     end
 
     #-----------------------------------------------------------------------------------------

--- a/lib/liberty_buildpack/services/vcap_services.rb
+++ b/lib/liberty_buildpack/services/vcap_services.rb
@@ -40,12 +40,18 @@ module LibertyBuildpack::Services
     def one_service?(filter, *required_credentials)
       candidates = select(&matcher(filter))
       match = false
-      if candidates.one?
+
+      if candidates.empty?
+        @logger.debug("Unable to resolve a single service plugin for service #{filter}. No matches exist")
+      elsif candidates.one?
         if credentials?(candidates.first['credentials'], required_credentials)
           match = true
         else
           @logger.warn("A service with a name label or tag matching #{filter} was found, but was missing one of the required credentials #{required_credentials}")
         end
+      else
+        @logger.error("Unable to resolve a single service plugin for service #{filter}. Found potential matches of #{candidates}.")
+        raise "Unable to resolve a single service plugin for service #{filter}. Multiple inexact matches exist."
       end
 
       match

--- a/spec/liberty_buildpack/framework/new_relic_agent_spec.rb
+++ b/spec/liberty_buildpack/framework/new_relic_agent_spec.rb
@@ -88,6 +88,15 @@ module LibertyBuildpack::Framework
           expect(detected).to eq(versionid)
         end
 
+        it 'should raise a runtime error for multiple valid new relic user services',
+           vcap_services_context: { def_type => [{ 'name' => 'newrelic', 'label' => def_label, 'tags' => def_tags,
+                                                   'credentials' => def_credentials }],
+                                  'servicetype2' => [{ 'name' => 'newrelic', 'label' => def_label, 'tags' => def_tags,
+                                                   'credentials' => def_credentials }] } do
+
+          expect { detected }.to raise_error(RuntimeError)
+        end
+
         it 'should be detected when the tag includes newrelic substring',
            vcap_services_context: { def_type => [{ 'name' => def_name, 'label' => def_label, 'tags' => ['newrelictag'],
                                                    'credentials' => def_credentials }] } do
@@ -109,22 +118,22 @@ module LibertyBuildpack::Framework
       end
 
       context 'application with one service' do
-        it 'should be detected when an application\'s service type includes newrelic',
+        it 'should be detected when an application has a valid service attribute that includes newrelic',
            vcap_services_context: { 'newrelic' => [{ 'name' => 'test-newrelic', 'label' => 'newrelic',
                                                      'credentials' => { 'licenseKey' => 'abcdef0123456789' } }] } do
 
           expect(detected).to eq(versionid)
         end
 
-        it 'should not be detected for an appication\'s service type that does not match newrelic',
+        it 'should not be detected if new relic service does not exist',
            vcap_services_context: { 'mysql' => [{ 'name' => 'test-mysql', 'label' => 'mysql',
                                                   'credentials' => { 'licenseKey' => '9876543210fedcba' } }] }do
 
           expect(detected).to eq(nil)
         end
 
-        it 'should detect based on the service instance name when the label and name are not the same',
-           vcap_services_context: { 'mysql' => [{ 'name' => 'test-postgres', 'label' => 'mysql',
+        it 'should not be detected since name is not used as a match check unless it is a user service',
+           vcap_services_context: { 'mysql' => [{ 'name' => 'test-newrelic', 'label' => 'mysql',
                                                   'credentials' => { 'licenseKey' => '9876543210fedcba' } }] }do
 
           expect(detected).to eq(nil)
@@ -139,6 +148,15 @@ module LibertyBuildpack::Framework
                                                   'credentials' => { 'licenseKey' => 'abcdef0123456789' } }] } do
 
           expect(detected).to eq(versionid)
+        end
+
+        it 'should raise a runtime error if multiple newrelic services exist',
+           vcap_services_context: { 'newrelickey1' => [{ 'name' => 'test-name', 'label' => 'newrelic',
+                                                  'credentials' => { 'licenseKey' => 'abcdef0123456789' } }],
+                                    'newrelickey2' => [{ 'name' => 'test-name', 'label' => 'newrelic',
+                                                  'credentials' => { 'licenseKey' => 'abcdef0123456789' } }] } do
+
+          expect { detected }.to raise_error(RuntimeError)
         end
 
         it 'should not be detected if none of the services is new relic',


### PR DESCRIPTION
To remain consistent with the handling of the other services, when more than one New Relic service is detected, an error should be raised.  These changes include:
1. avoid checking of the service key quick test so that all services are processed to determine if there's multiple New Relic services
2. raise an error when there's multiple matches detected by the service manager
3. updated tests and some clean up of test descriptions
4. updated doc