### PR TITLE
support Heroku

### DIFF
--- a/lib/liberty_buildpack/buildpack_version.rb
+++ b/lib/liberty_buildpack/buildpack_version.rb
@@ -99,8 +99,6 @@ module LibertyBuildpack
 
     GIT_DIR = (Pathname.new(__FILE__).dirname + '../../.git').freeze
 
-    private_constant :GIT_DIR
-
     def remote_string
       "#{@remote}##{@hash}" if @remote && !@remote.empty? && @hash && !@hash.empty?
     end

--- a/lib/liberty_buildpack/framework/env.rb
+++ b/lib/liberty_buildpack/framework/env.rb
@@ -84,7 +84,7 @@ module LibertyBuildpack::Framework
     private
 
     def has_configuration?
-      !@configuration.nil? && @configuration.size > 0
+      !@configuration.nil? && @configuration.size > 0 && !'---'.eql?(@configuration)
     end
 
     def copy_variables(variables, configuration)

--- a/lib/liberty_buildpack/framework/spring_auto_reconfiguration/web_xml_modifier.rb
+++ b/lib/liberty_buildpack/framework/spring_auto_reconfiguration/web_xml_modifier.rb
@@ -76,8 +76,6 @@ module LibertyBuildpack::Framework
 
       DISPATCHER_SERVLET = 'DispatcherServlet'.freeze
 
-      # private_constant :CONTEXT_INITIALIZER_CLASSES, :CONTEXT_LOADER_LISTENER, :DISPATCHER_SERVLET
-
       def augment(root, param_type)
         classes_string = xpath(root, "#{param_type}[param-name[contains(text(), '#{CONTEXT_INITIALIZER_CLASSES}')]]/param-value/text()").first
         classes_string = create_param(root, param_type, CONTEXT_INITIALIZER_CLASSES, '') unless classes_string

--- a/lib/liberty_buildpack/jre/memory/memory_range.rb
+++ b/lib/liberty_buildpack/jre/memory/memory_range.rb
@@ -113,8 +113,6 @@ module LibertyBuildpack
 
       RANGE_SEPARATOR = '..'.freeze
 
-      private_constant :RANGE_SEPARATOR
-
       def get_bounds(range)
         if range.index(RANGE_SEPARATOR)
           lower_bound, upper_bound = range.split(RANGE_SEPARATOR)

--- a/lib/liberty_buildpack/jre/memory/memory_size.rb
+++ b/lib/liberty_buildpack/jre/memory/memory_size.rb
@@ -136,8 +136,6 @@ module LibertyBuildpack
 
       KILO = 1024.freeze
 
-      private_constant :KILO
-
       def memory_size_operation(other)
         fail "Invalid parameter: instance of #{other.class} is not a MemorySize" unless other.is_a? MemorySize
         from_numeric(yield @bytes, other.bytes)

--- a/lib/liberty_buildpack/jre/memory/openjdk_memory_heuristic_factory.rb
+++ b/lib/liberty_buildpack/jre/memory/openjdk_memory_heuristic_factory.rb
@@ -43,8 +43,6 @@ module LibertyBuildpack
 
         VALID_TYPES = %w(heap stack native).freeze
 
-        private_constant :VALID_TYPES
-
         JAVA_OPTS = {
           'heap'      => ->(v) { %W(-Xmx#{v} -Xms#{v}) },
           'metaspace' => ->(v) { %W(-XX:MaxMetaspaceSize=#{v} -XX:MetaspaceSize=#{v}) },

--- a/lib/liberty_buildpack/jre/memory/stack_memory_bucket.rb
+++ b/lib/liberty_buildpack/jre/memory/stack_memory_bucket.rb
@@ -43,9 +43,9 @@ module LibertyBuildpack
         range.floor == 0 ? JVM_DEFAULT_STACK_SIZE : range.floor
       end
 
-      JVM_DEFAULT_STACK_SIZE = MemorySize.new('1M').freeze
+      private
 
-      private_constant :JVM_DEFAULT_STACK_SIZE
+      JVM_DEFAULT_STACK_SIZE = MemorySize.new('1M').freeze
 
     end
 

--- a/lib/liberty_buildpack/jre/memory/weight_balancing_memory_heuristic.rb
+++ b/lib/liberty_buildpack/jre/memory/weight_balancing_memory_heuristic.rb
@@ -69,8 +69,6 @@ module LibertyBuildpack
 
       CLOSE_TO_DEFAULT_FACTOR = 0.1.freeze
 
-      private_constant :NATIVE_MEMORY_WARNING_FACTOR, :TOTAL_MEMORY_WARNING_FACTOR, :CLOSE_TO_DEFAULT_FACTOR
-
       def allocate_lower_bounds(buckets)
         buckets.each_value do |bucket|
           bucket.size = bucket.range.floor

--- a/lib/liberty_buildpack/util/cache/download_cache.rb
+++ b/lib/liberty_buildpack/util/cache/download_cache.rb
@@ -21,6 +21,7 @@ require 'liberty_buildpack/util/cache/admin_cache'
 require 'liberty_buildpack/util/cache/buildpack_stash'
 require 'liberty_buildpack/util/cache/file_cache'
 require 'liberty_buildpack/util/cache/internet_availability'
+require 'liberty_buildpack/util/heroku'
 require 'monitor'
 require 'net/http'
 require 'tmpdir'
@@ -194,6 +195,12 @@ module LibertyBuildpack::Util::Cache
     end
 
     def issue_http_request(request, uri, &block)
+      # Workaround for "sslv3 alert handshake failure" error in the environment where the buildpack
+      # is staged on Heroku.
+      # Both the detect and compile phases fail when using SSL.
+      if LibertyBuildpack::Util::Heroku.heroku? && uri.include?('download.run.pivotal.io')
+        uri = uri.sub('https', 'http')
+      end
       add_user_agent_header(request)
       1.upto(retry_limit) do |try|
         begin


### PR DESCRIPTION
Since the buildpack was initially updated to work on Heroku last summer, there have been a few commits that were incompatible. They still stage the buildpack with ruby 1.9.2 so I updated a few instances of ruby 1.9.3 syntax and a related problem parsing yml files. The big problem is downloads from https://download.run.pivotal.io not working, the error being "SSLconnect returned=1 errno=0 state=unknown state: sslv3 alert handshake failure". The only way I've been able to get it to work was to not use SSL for the download. I didn't have any success otherwise changing the http_options method in download_cache.rb like different SSL versions or providing my own CA certificate. 