### PR TITLE
TLS SNI fix for Ruby 1.9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
   include:
     - rvm: "1.9.3-p545"
       env: COMMAND=rake
-#    - rvm: "1.9.2"
-#      env: COMMAND=rspec
+    - rvm: "1.9.2"
+      env: COMMAND=rspec
 install: bundle install --deployment --without debug
 script: bundle exec $COMMAND

--- a/lib/liberty_buildpack/util/http.rb
+++ b/lib/liberty_buildpack/util/http.rb
@@ -1,0 +1,38 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2015 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'net/http'
+require 'uri'
+
+# The Net:HTTP library in Ruby 1.9.2 does not send SNI TLS extension. The extension maybe
+# be required by certain web sites.
+# This class extends the Net:HTTP class and sets the SNI extension on older Ruby runtime.
+module LibertyBuildpack::Util
+
+  # Provides SNI TLS work-around for Net::HTTP
+  class HTTP < Net::HTTP
+
+    def use_ssl?
+      # Set SNI TLS extension on SSLSocket if using older Ruby
+      if @use_ssl && RUBY_VERSION < '1.9.3' && !@socket.nil? && !@socket.io.nil?
+        @socket.io.hostname = @address if @socket.io.respond_to? :hostname=
+      end
+      @use_ssl
+    end
+
+  end
+
+end

--- a/spec/liberty_buildpack/buildpack_spec.rb
+++ b/spec/liberty_buildpack/buildpack_spec.rb
@@ -70,7 +70,7 @@ module LibertyBuildpack
 
     it 'should not write VCAP_SERVICES credentials as debug info',
        log_level: 'DEBUG' do
-      ENV['VCAP_SERVICES'] = '{"type":[{"credentials":"VERY SECRET PHRASE","plain":"PLAIN DATA"}]}'
+      ENV['VCAP_SERVICES'] = "{\"type\":\n[\n{\"credentials\":\n\"VERY SECRET PHRASE\", \"plain\":\n\"PLAIN DATA\"}]}"
       log_content = with_buildpack do |buildpack|
         app_dir = File.dirname buildpack.instance_variable_get(:@lib_directory)
         File.read LibertyBuildpack::Diagnostics.get_buildpack_log app_dir


### PR DESCRIPTION
Set SNI TLS extension when running on Ruby 1.9.2.
