### PR TITLE
remove surrounding quotes in the new relic appname

### DIFF
--- a/lib/liberty_buildpack/framework/new_relic_agent.rb
+++ b/lib/liberty_buildpack/framework/new_relic_agent.rb
@@ -94,7 +94,7 @@ module LibertyBuildpack::Framework
       @java_opts << "-javaagent:#{nr_agent}"
       @java_opts << "-Dnewrelic.home=#{nr_home_dir}"
       @java_opts << "-Dnewrelic.config.license_key=#{vcap_nr_license}"
-      @java_opts << "-Dnewrelic.config.app_name=\'#{vcap_app_name}\'"
+      @java_opts << "-Dnewrelic.config.app_name=#{vcap_app_name}"
       @java_opts << "-Dnewrelic.config.log_file_path=#{nr_logs_dir}"
     end
 

--- a/spec/liberty_buildpack/framework/new_relic_agent_spec.rb
+++ b/spec/liberty_buildpack/framework/new_relic_agent_spec.rb
@@ -249,7 +249,7 @@ module LibertyBuildpack::Framework
         expect(released).to include("-javaagent:./#{newrelic_home}/#{versionid}.jar")
         expect(released).to include("-Dnewrelic.home=./#{newrelic_home}")
         expect(released).to include('-Dnewrelic.config.license_key=abcdefghijklmnop1234')
-        expect(released).to include('-Dnewrelic.config.app_name=\'TestApp\'')
+        expect(released).to include('-Dnewrelic.config.app_name=TestApp')
         expect(released).to include("-Dnewrelic.config.log_file_path=./#{newrelic_home}/logs")
       end
 
@@ -261,7 +261,7 @@ module LibertyBuildpack::Framework
         expect(released).to include("-javaagent:../../../#{newrelic_home}/#{versionid}.jar")
         expect(released).to include("-Dnewrelic.home=../../../#{newrelic_home}")
         expect(released).to include('-Dnewrelic.config.license_key=abcdefghijklmnop1234')
-        expect(released).to include('-Dnewrelic.config.app_name=\'TestApp\'')
+        expect(released).to include('-Dnewrelic.config.app_name=TestApp')
         expect(released).to include("-Dnewrelic.config.log_file_path=../../../#{newrelic_home}/logs")
       end
     end # end of release


### PR DESCRIPTION
The single quotes surrounding the application name applied to the New Relic configuration is not required.  The application name from the New Relic configuration will appear in the New Relic dashboard, so the single quotes should be removed.