### PR TITLE
fix broken links in forking.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,15 +89,10 @@ bundle install --gemfile Gemfile.rubymine-debug
 [install additional gems]: http://stackoverflow.com/questions/11732715/how-do-i-install-ruby-debug-base19x-on-mountain-lion-for-intellij
 [pull request]: https://help.github.com/articles/using-pull-requests
 [Pull requests]: http://help.github.com/send-pull-requests
-[example]: docs/util-repositories.md#setting-up-your-web-server
 [options]: docs/server-xml-options.md
 [tuning options]: docs/tuning.md
 [java main push]: docs/java-main.md
-[Repositories]: docs/util-repositories.md
-[ibmjdk.yml]: config/ibmjdk.yml
-[liberty.yml]: config/liberty.yml
-[wasdev.net]: http://wasdev.net
-[developerWorks Java site]: https://www.ibm.com/developerworks/java/jdk/
+
 [Liberty-License]: http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/8.5.5.3/lafiles/runtime//en.html
 [JVM-License]: http://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=&li_formnum=L-EWOD-99YA4J&title=IBM%C2%AE+SDK%2C+Java+Technology+Edition%2C+Version+7+Release+1&l=en
 [manifest documentation]: http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html

--- a/docs/forking.md
+++ b/docs/forking.md
@@ -12,7 +12,7 @@ To fork the Buildpack and host your own binaries, then complete the following:
   The download will be in an archive .bin format.
    
 5. Copy the binaries to a location that the buildpack will be able to access via HTTP. For details see
-  [Repositories][]. For an example see [Setting up your Web Server][example]
+  [Repositories][]. For an example see [Setting up your Web Server][]
 
 6. Modify the code in [`config/ibmjdk.yml`][ibmjdk.yml] to point to the JRE.
 
@@ -24,3 +24,10 @@ To fork the Buildpack and host your own binaries, then complete the following:
 ```bash
 cf push <APP-NAME> -p <ARCHIVE> -b <URL to forked repository>
 ```
+
+[wasdev.net]: http://wasdev.net
+[developerWorks Java site]: https://www.ibm.com/developerworks/java/jdk/
+[Repositories]: util-repositories.md
+[Setting up your Web Server]: util-repositories.md#setting-up-your-web-server
+[ibmjdk.yml]: ../config/ibmjdk.yml
+[liberty.yml]: ../config/liberty.yml


### PR DESCRIPTION
Looks like when the forking documentation was moved out of README.md and into its own file all the links weren't copied with it.