### PR TITLE
Add JRebel support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .yardoc
 .buildpath
 .project
+*.iml
 admin_cache
 coverage
 config/licenses.yml

--- a/config/components.yml
+++ b/config/components.yml
@@ -26,3 +26,4 @@ frameworks:
   - "LibertyBuildpack::Framework::JavaOpts"
   - "LibertyBuildpack::Framework::SpringAutoReconfiguration"
   - "LibertyBuildpack::Framework::NewRelicAgent"
+  - "LibertyBuildpack::Framework::JRebelAgent"

--- a/config/jrebelagent.yml
+++ b/config/jrebelagent.yml
@@ -1,0 +1,19 @@
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Service configuration
+---
+version: 6.0.3
+repository_root: "http://dl.zeroturnaround.com/jrebel/"

--- a/lib/liberty_buildpack/framework/jrebel_agent.rb
+++ b/lib/liberty_buildpack/framework/jrebel_agent.rb
@@ -1,0 +1,117 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require 'liberty_buildpack/diagnostics/logger_factory'
+require 'liberty_buildpack/framework'
+require 'liberty_buildpack/repository/configured_item'
+require 'liberty_buildpack/util/download'
+require 'liberty_buildpack/container/common_paths'
+require 'liberty_buildpack/container/container_utils'
+
+module LibertyBuildpack::Framework
+
+  # Provides the required detect/compile/release functionality in order to use JRebel with an application
+  class JRebelAgent
+
+    # JRebel home directory
+    JR_HOME_DIR = '.jrebel'.freeze
+    # Name of the main jar file
+    JREBEL_JAR = 'jrebel.jar'
+    # Directory name
+    JREBEL = 'jrebel'
+    # Path tho the native agent within the nosetup.zip
+    LIBJREBEL_SO = File.join(JREBEL, 'lib', 'libjrebel64.so')
+
+    # Creates an instance, passing in a context of information available to the component
+    #
+    # @param [Hash] context the context that is provided to the instance
+    # @option context [String] :app_dir the directory that the application exists in
+    # @option context [Hash] :configuration the properties provided by the user
+    # @option context [CommonPaths] :common_paths the set of paths common across components that components should reference
+    # @option context [Hash] :vcap_application the application information provided by cf
+    # @option context [Hash] :vcap_services the services bound to the application provided by cf
+    # @option context [Array<String>] :java_opts an array that Java options can be added to
+    def initialize(context = {})
+      @logger = LibertyBuildpack::Diagnostics::LoggerFactory.get_logger
+      @app_dir = context[:app_dir]
+      @configuration = context[:configuration]
+      @common_paths = context[:common_paths] || LibertyBuildpack::Container::CommonPaths.new
+      @java_opts = context[:java_opts]
+    end
+
+    #-----------------------------------------------------------------------------------------
+    # Determines if the application contains a rebel-remote.xml to provide a configured jrebel agent
+    #
+    # @return [String] the detected versioned ID if the environment and config are valid, otherwise nil
+    #------------------------------------------------------------------------------------------
+    def detect
+      if File.exists?("#{@app_dir}/WEB-INF/classes/rebel-remote.xml")
+        @logger.info('Found rebel-remote.xml, enabling JRebel')
+        @version, @uri = LibertyBuildpack::Repository::ConfiguredItem.find_item(@configuration)
+        @nosetup_zip = "jrebel-#{@version}-nosetup.zip"
+        "jrebel-#{@version}"
+      else
+        @logger.debug('No rebel-remote.xml found in the application.')
+        nil
+      end
+    end
+
+    #-----------------------------------------------------------------------------------------
+    # Create the JRebel directory and its contents for the app droplet.
+    #------------------------------------------------------------------------------------------
+    def compile
+      if @app_dir.nil?
+        raise 'app directory must be provided'
+      elsif @version.nil? || @uri.nil? || @nosetup_zip.nil?
+        raise "Version #{@version}, uri #{@uri}, or new jrebel-nosetup.zip #{@nosetup_zip} is not available, detect needs to be invoked"
+      end
+
+      jr_home = File.join(@app_dir, JR_HOME_DIR)
+      FileUtils.mkdir_p(jr_home)
+
+      download_nosetup_zip(jr_home)
+      FileUtils.rm_r(File.join(jr_home, JREBEL)) if File.exist?(File.join(jr_home, JREBEL))
+      LibertyBuildpack::Container::ContainerUtils.unzip(File.join(jr_home, @nosetup_zip), jr_home)
+    end
+
+    #-----------------------------------------------------------------------------------------
+    # Download the JRebel zip from the repository as specified in the JRebel configuration.
+    #------------------------------------------------------------------------------------------
+    def download_nosetup_zip(jr_home)
+      LibertyBuildpack::Util.download(@version, @uri, 'JRebel zip', @nosetup_zip, jr_home)
+    rescue => e
+      raise "Unable to download the JRebel zip. Ensure that the zip at #{@uri} is available and accessible. #{e.message}"
+    end
+
+    #-----------------------------------------------------------------------------------------
+    # Create the JRebel agent options appended as java_opts.
+    #------------------------------------------------------------------------------------------
+    def release
+      app_dir = @common_paths.relative_location
+
+      jr_home = File.join(app_dir, JR_HOME_DIR)
+      jr_native_agent = File.join(jr_home, LIBJREBEL_SO)
+
+      jr_log = File.join(@common_paths.log_directory, 'jrebel.log')
+
+      @java_opts << "-agentpath:#{jr_native_agent}"
+      @java_opts << '-Xshareclasses:none'
+      @java_opts << '-Drebel.remoting_plugin=true'
+      @java_opts << '-Drebel.redefine_class=false'
+      @java_opts << '-Drebel.log=true'
+      @java_opts << "-Drebel.log.file=#{jr_log}"
+    end
+  end
+end

--- a/spec/fixtures/jrebel_test_app_no_rebel_remote/WEB-INF/classes/rebel.xml
+++ b/spec/fixtures/jrebel_test_app_no_rebel_remote/WEB-INF/classes/rebel.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com"
+             xsi:schemaLocation="http://www.zeroturnaround.com http://www.zeroturnaround.com/alderaan/rebel-2_0.xsd">
+  <classpath>
+    <dir name="my/dir"/>    
+  </classpath>
+</application>

--- a/spec/fixtures/jrebel_test_app_with_rebel_remote/WEB-INF/classes/rebel-remote.xml
+++ b/spec/fixtures/jrebel_test_app_with_rebel_remote/WEB-INF/classes/rebel-remote.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rebel-remote>
+    <id>demo</id>
+    <publicKey>1234567890</publicKey>
+</rebel-remote>

--- a/spec/liberty_buildpack/framework/jrebel_agent_spec.rb
+++ b/spec/liberty_buildpack/framework/jrebel_agent_spec.rb
@@ -1,0 +1,157 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+require 'spec_helper'
+require 'component_helper'
+require 'liberty_buildpack/framework/jrebel_agent'
+require 'liberty_buildpack/container/common_paths'
+
+module LibertyBuildpack::Framework
+
+  describe 'JRebelAgent' do
+    include_context 'component_helper'    # component context
+
+    JREBEL_VERSION = LibertyBuildpack::Util::TokenizedVersion.new('6.0.3')
+    JREBEL_DETAILS = [JREBEL_VERSION, 'test-uri']
+    # test data
+    let(:jrebel_home) { '.jrebel' }   # the expected staged newrelic agent directory
+    let(:application_cache) { double('ApplicationCache') }
+    let(:version) { '6.0.3' }
+    let(:versionid) { "jrebel-#{version}-nosetup.zip" }
+
+    before do | example |
+      # an index.yml entry returned from the index.yml of the new relic repository
+      if example.metadata[:index_version]
+        # new relic index.yml info provided by tests
+        index_version = example.metadata[:index_version]
+        index_uri = example.metadata[:index_uri]
+        index_license = example.metadata[:index_license]
+      else
+        # default values for the new relic index.yml info for tests
+        index_version = version
+        index_uri =  "https://downloadsite/jrebel/#{versionid}.jar"
+      end
+
+      # By default, always stub the return of a valid index.yml entry
+      find_item = example.metadata[:return_find_item].nil? ? true : example.metadata[:return_find_item]
+      if find_item
+        index_yml_entry = [LibertyBuildpack::Util::TokenizedVersion.new(index_version), index_uri, index_license]
+        LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item).and_return(index_yml_entry)
+      else
+        # tests can set find_item=false and a raise_error_message to mock a failed return of processing the index.yml
+        LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item).and_raise(example.metadata[:raise_error_message])
+      end
+
+      # For a download request of a new relic agent jar, return the fixture jar
+      LibertyBuildpack::Util::ApplicationCache.stub(:new).and_return(application_cache)
+      application_cache.stub(:get).with(index_uri).and_yield(File.open('spec/fixtures/stub-new-relic-agent.jar'))
+    end
+
+    describe 'configuration' do
+      it 'must have 6.0.3 as the configured version' do
+        configuration = YAML.load_file(File.expand_path('../../../config/jrebelagent.yml', File.dirname(__FILE__)))
+        expect(LibertyBuildpack::Repository::ConfiguredItem.find_item(configuration)[0]).to eq(JREBEL_VERSION)
+      end
+    end
+
+    describe 'detect' do
+      it 'should not attach JRebel agent when no rebel-remote.xml in the application' do
+        LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item).and_return(JREBEL_DETAILS)
+
+        detected = JRebelAgent.new(
+            app_dir: 'spec/fixtures/jrebel_test_app_no_rebel_remote',
+            configuration: {}
+        ).detect
+
+        expect(detected).to be_nil
+      end
+
+      it 'should attach JRebel agent when rebel-remote.xml is in the application' do
+        LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item).and_return(JREBEL_DETAILS)
+
+        detected = JRebelAgent.new(
+            app_dir: 'spec/fixtures/jrebel_test_app_with_rebel_remote',
+            configuration: {}
+        ).detect
+
+        expect(detected).to eq('jrebel-6.0.3')
+      end
+    end # end of detect tests
+
+    describe 'compile' do
+
+      before do
+        FileUtils.mkdir_p("#{app_dir}/WEB-INF/classes/")
+        FileUtils.touch("#{app_dir}/WEB-INF/classes/rebel-remote.xml")
+      end
+
+      subject(:compiled) do
+        jrebel = JRebelAgent.new(context)
+        jrebel.detect
+        jrebel.compile
+      end
+
+      it 'should create a JRebel home directory in the application root' do
+        compiled
+        expect(File.exists?(File.join(app_dir, jrebel_home))).to eq(true)
+      end
+
+      describe 'download JRebel agent jar based on index.yml information' do
+        it 'should download the agent with a matching key and jar version' do
+          expect { compiled }.to output(%r{Downloading JRebel zip #{version} from https://downloadsite/jrebel/jrebel-#{version}-nosetup.zip}).to_stdout
+          expect(File.exists?(File.join(app_dir, jrebel_home, versionid))).to eq(true)
+        end
+
+        it 'should raise an error with original exception if the jar could not be downloaded',
+           index_version: '6.0.3', index_uri: 'https://downloadsite/jrebel/jrebel-6.0.3-nosetup.zip' do
+          allow(LibertyBuildpack::Util).to receive(:download).and_raise('underlying download error')
+          expect { compiled }.to raise_error(/Unable to download the JRebel zip\. Ensure that the zip at..+underlying download error/)
+        end
+      end
+    end # end compile
+
+    describe 'release', java_opts: [] do
+
+      subject(:released) do
+        jrebel = JRebelAgent.new(context)
+        jrebel.detect
+        jrebel.release
+      end
+
+      it 'should return command line options for a valid service in a default container' do
+        expect(released).to include('-agentpath:./.jrebel/jrebel/lib/libjrebel64.so')
+        expect(released).to include('-Xshareclasses:none')
+        expect(released).to include('-Drebel.remoting_plugin=true')
+        expect(released).to include('-Drebel.redefine_class=false')
+        expect(released).to include('-Drebel.log=true')
+        expect(released).to include('-Drebel.log.file=./../logs/jrebel.log')
+      end
+
+      it 'should return command line options for a valid service in a container with an adjusted relative location',
+         common_paths: LibertyBuildpack::Container::CommonPaths.new do |example|
+
+        example.metadata[:common_paths].relative_location = 'custom/container/dir'
+
+        expect(released).to include('-agentpath:../../../.jrebel/jrebel/lib/libjrebel64.so')
+        expect(released).to include('-Xshareclasses:none')
+        expect(released).to include('-Drebel.remoting_plugin=true')
+        expect(released).to include('-Drebel.redefine_class=false')
+        expect(released).to include('-Drebel.log=true')
+        expect(released).to include('-Drebel.log.file=../../../../logs/jrebel.log')
+      end
+    end # end of release
+  end
+end


### PR DESCRIPTION
JRebel is implemented as a framework. The JRebel Java agent is attached to the JVM whenever there is a /WEB-INF/classes/rebel-remote.xml file present in the application directory. Currently only WAR applications are supported.