### PR TITLE
Make sure JRebel at least starts with OpenJDK

### DIFF
--- a/lib/liberty_buildpack/framework/jrebel_agent.rb
+++ b/lib/liberty_buildpack/framework/jrebel_agent.rb
@@ -40,6 +40,7 @@ module LibertyBuildpack::Framework
       @configuration = context[:configuration]
       @common_paths = context[:common_paths] || LibertyBuildpack::Container::CommonPaths.new
       @java_opts = context[:java_opts]
+      @jvm_type = context[:jvm_type]
     end
 
     #-----------------------------------------------------------------------------------------
@@ -87,11 +88,12 @@ module LibertyBuildpack::Framework
       jr_log = File.join(@common_paths.log_directory, 'jrebel.log')
 
       @java_opts << "-agentpath:#{jr_native_agent}"
-      @java_opts << '-Xshareclasses:none'
       @java_opts << '-Drebel.remoting_plugin=true'
       @java_opts << '-Drebel.redefine_class=false'
       @java_opts << '-Drebel.log=true'
       @java_opts << "-Drebel.log.file=#{jr_log}"
+
+      @java_opts << '-Xshareclasses:none' unless openjdk?
     end
 
     private
@@ -125,5 +127,10 @@ module LibertyBuildpack::Framework
       LibertyBuildpack::Container::ContainerUtils.unzip(file, jr_home)
       puts "(#{(Time.now - install_start_time).duration})\n"
     end
+
+    def openjdk?
+      @jvm_type != nil && 'openjdk'.casecmp(@jvm_type) == 0
+    end
+
   end
 end

--- a/spec/component_helper.rb
+++ b/spec/component_helper.rb
@@ -34,6 +34,7 @@ shared_context 'component_helper' do
       license_ids:    example.metadata[:license_ids],
       configuration:  example.metadata[:configuration],
       common_paths:   example.metadata[:common_paths],
+      jvm_type:       example.metadata[:jvm_type],
       vcap_application: example.metadata[:vcap_application_context],
       vcap_services:  example.metadata[:vcap_services_context] }
   end

--- a/spec/liberty_buildpack/framework/jrebel_agent_spec.rb
+++ b/spec/liberty_buildpack/framework/jrebel_agent_spec.rb
@@ -129,28 +129,42 @@ module LibertyBuildpack::Framework
         jrebel = JRebelAgent.new(context)
         jrebel.detect
         jrebel.release
+        context[:java_opts]
       end
 
-      it 'should return command line options for a valid service in a default container' do
-        expect(released).to include('-agentpath:./.jrebel/jrebel/lib/libjrebel64.so')
-        expect(released).to include('-Xshareclasses:none')
-        expect(released).to include('-Drebel.remoting_plugin=true')
-        expect(released).to include('-Drebel.redefine_class=false')
-        expect(released).to include('-Drebel.log=true')
-        expect(released).to include('-Drebel.log.file=./../logs/jrebel.log')
+      it 'should return command line options for a valid service in a default container',
+         java_opts: [] do | example |
+        java_opts = released
+        expect(java_opts).to include('-agentpath:./.jrebel/jrebel/lib/libjrebel64.so')
+        expect(java_opts).to include('-Xshareclasses:none')
+        expect(java_opts).to include('-Drebel.remoting_plugin=true')
+        expect(java_opts).to include('-Drebel.redefine_class=false')
+        expect(java_opts).to include('-Drebel.log=true')
+        expect(java_opts).to include('-Drebel.log.file=./../logs/jrebel.log')
+      end
+
+      it 'should return command line options for a valid service in a default container with openjdk',
+         java_opts: [], jvm_type: 'openjdk' do | example |
+        java_opts = released
+        expect(java_opts).to include('-agentpath:./.jrebel/jrebel/lib/libjrebel64.so')
+        expect(java_opts).not_to include('-Xshareclasses:none')
+        expect(java_opts).to include('-Drebel.remoting_plugin=true')
+        expect(java_opts).to include('-Drebel.redefine_class=false')
+        expect(java_opts).to include('-Drebel.log=true')
+        expect(java_opts).to include('-Drebel.log.file=./../logs/jrebel.log')
       end
 
       it 'should return command line options for a valid service in a container with an adjusted relative location',
-         common_paths: LibertyBuildpack::Container::CommonPaths.new do |example|
-
+         java_opts: [], common_paths: LibertyBuildpack::Container::CommonPaths.new do |example|
         example.metadata[:common_paths].relative_location = 'custom/container/dir'
 
-        expect(released).to include('-agentpath:../../../.jrebel/jrebel/lib/libjrebel64.so')
-        expect(released).to include('-Xshareclasses:none')
-        expect(released).to include('-Drebel.remoting_plugin=true')
-        expect(released).to include('-Drebel.redefine_class=false')
-        expect(released).to include('-Drebel.log=true')
-        expect(released).to include('-Drebel.log.file=../../../../logs/jrebel.log')
+        java_opts = released
+        expect(java_opts).to include('-agentpath:../../../.jrebel/jrebel/lib/libjrebel64.so')
+        expect(java_opts).to include('-Xshareclasses:none')
+        expect(java_opts).to include('-Drebel.remoting_plugin=true')
+        expect(java_opts).to include('-Drebel.redefine_class=false')
+        expect(java_opts).to include('-Drebel.log=true')
+        expect(java_opts).to include('-Drebel.log.file=../../../../logs/jrebel.log')
       end
     end # end of release
   end


### PR DESCRIPTION
The -Xshareclasses:none option is IBM JRE specific so do not add it if using OpenJDK.
