### PR TITLE
Another update for JRebel on OpenJDK

### DIFF
--- a/lib/liberty_buildpack/framework/jrebel_agent.rb
+++ b/lib/liberty_buildpack/framework/jrebel_agent.rb
@@ -89,11 +89,13 @@ module LibertyBuildpack::Framework
 
       @java_opts << "-agentpath:#{jr_native_agent}"
       @java_opts << '-Drebel.remoting_plugin=true'
-      @java_opts << '-Drebel.redefine_class=false'
       @java_opts << '-Drebel.log=true'
       @java_opts << "-Drebel.log.file=#{jr_log}"
 
-      @java_opts << '-Xshareclasses:none' unless openjdk?
+      unless openjdk?
+        @java_opts << '-Drebel.redefine_class=false'
+        @java_opts << '-Xshareclasses:none'
+      end
     end
 
     private

--- a/spec/liberty_buildpack/framework/jrebel_agent_spec.rb
+++ b/spec/liberty_buildpack/framework/jrebel_agent_spec.rb
@@ -149,7 +149,7 @@ module LibertyBuildpack::Framework
         expect(java_opts).to include('-agentpath:./.jrebel/jrebel/lib/libjrebel64.so')
         expect(java_opts).not_to include('-Xshareclasses:none')
         expect(java_opts).to include('-Drebel.remoting_plugin=true')
-        expect(java_opts).to include('-Drebel.redefine_class=false')
+        expect(java_opts).not_to include('-Drebel.redefine_class=false')
         expect(java_opts).to include('-Drebel.log=true')
         expect(java_opts).to include('-Drebel.log.file=./../logs/jrebel.log')
       end


### PR DESCRIPTION
The -Drebel.redefine_class=false property is not needed on OpenJDK.
