### PR TITLE
add enable configuration option for jrebelagent

### DIFF
--- a/config/jrebelagent.yml
+++ b/config/jrebelagent.yml
@@ -1,5 +1,5 @@
 # IBM WebSphere Application Server Liberty Buildpack
-# Copyright 2014 the original author or authors.
+# Copyright 2015 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,3 +17,4 @@
 ---
 version: 6.+
 repository_root: "https://dl.zeroturnaround.com/jrebel/"
+enabled: true

--- a/lib/liberty_buildpack/framework/jrebel_agent.rb
+++ b/lib/liberty_buildpack/framework/jrebel_agent.rb
@@ -1,6 +1,6 @@
 # Encoding: utf-8
 # IBM WebSphere Application Server Liberty Buildpack
-# Copyright 2014 the original author or authors.
+# Copyright 2015 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 require 'liberty_buildpack/diagnostics/logger_factory'
 require 'liberty_buildpack/framework'
 require 'liberty_buildpack/repository/configured_item'
@@ -49,6 +50,8 @@ module LibertyBuildpack::Framework
     # @return [String] the detected versioned ID if the environment and config are valid, otherwise nil
     #------------------------------------------------------------------------------------------
     def detect
+      return nil unless enabled?
+
       rebel_remote_xmls = Dir.glob(["#{@app_dir}/**/rebel-remote.xml"])
 
       @logger.debug("rebel_remote_xmls=[#{rebel_remote_xmls.join(', ')}]")
@@ -136,6 +139,10 @@ module LibertyBuildpack::Framework
 
     def openjdk?
       @jvm_type != nil && 'openjdk'.casecmp(@jvm_type) == 0
+    end
+
+    def enabled?
+      @configuration['enabled'].nil? || @configuration['enabled']
     end
 
   end

--- a/spec/liberty_buildpack/framework/jrebel_agent_spec.rb
+++ b/spec/liberty_buildpack/framework/jrebel_agent_spec.rb
@@ -1,6 +1,6 @@
 # Encoding: utf-8
 # IBM WebSphere Application Server Liberty Buildpack
-# Copyright 2014 the original author or authors.
+# Copyright 2015 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -126,9 +126,19 @@ module LibertyBuildpack::Framework
 
         expect(detected).to eq('jrebel-6.0.3')
       end
+
+      it 'should not attach JRebel agent when disabled' do
+        detected = JRebelAgent.new(
+            app_dir: 'spec/fixtures/jrebel_test_app_with_rebel_remote',
+            configuration: { 'enabled' => false }
+        ).detect
+
+        expect(detected).to be_nil
+      end
+
     end # end of detect tests
 
-    describe 'compile' do
+    describe 'compile', configuration: {} do
 
       before do
         FileUtils.mkdir_p("#{app_dir}/WEB-INF/classes/")
@@ -160,7 +170,7 @@ module LibertyBuildpack::Framework
       end
     end # end compile
 
-    describe 'release', java_opts: [] do
+    describe 'release', java_opts: [], configuration: {} do
 
       subject(:released) do
         jrebel = JRebelAgent.new(context)


### PR DESCRIPTION
Sometimes it might be necessary to disable the JRebel framework. This 'enable' configuration option will allow for that.
