### PR TITLE
Recognize context-root from ibm-web-ext.xml file

### DIFF
--- a/lib/liberty_buildpack/container/web_xml_ext.rb
+++ b/lib/liberty_buildpack/container/web_xml_ext.rb
@@ -1,0 +1,56 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2015 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'liberty_buildpack/diagnostics/logger_factory'
+require 'liberty_buildpack/util/xml_utils'
+
+module LibertyBuildpack::Container
+
+  # The class that provides abstractions for ibm-web-ext.xml file.
+  class WebXmlExt
+
+    # Reads ibm-web-ext.xml file.
+    #
+    # @return [WebXmlExt] returns +nil+ if file does not exist or is malformed.
+    def self.read(ibm_web_ext)
+      if File.exist?(ibm_web_ext)
+        begin
+          return WebXmlExt.new(LibertyBuildpack::Util::XmlUtils.read_xml_file(ibm_web_ext))
+        rescue => e
+          logger = LibertyBuildpack::Diagnostics::LoggerFactory.get_logger
+          logger.debug("Error reading ibm-web-ext.xml file: Exception #{e.message}")
+        end
+      end
+      nil
+    end
+
+    def initialize(doc = nil)
+      @doc = doc
+    end
+
+    # Returns context-root specified in the ibm-web-ext.xml file.
+    #
+    # @return [String] returns context-root specified in the file.
+    def get_context_root
+      unless @doc.nil?
+        element = @doc.elements['/web-ext/context-root']
+        return element.attributes['uri'] unless element.nil?
+      end
+      nil
+    end
+
+  end
+end

--- a/spec/fixtures/ibm-web-ext-bad.xml
+++ b/spec/fixtures/ibm-web-ext-bad.xml
@@ -1,0 +1,8 @@
+<web-ext
+  xmlns="http://websphere.ibm.com/xml/ns/javaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-ext_1_0.xsd"
+  version="1.0"
+>
+  <context-root uri="myContext">
+</web-ext>

--- a/spec/fixtures/ibm-web-ext-no-context.xml
+++ b/spec/fixtures/ibm-web-ext-no-context.xml
@@ -1,0 +1,8 @@
+<web-ext
+  xmlns="http://websphere.ibm.com/xml/ns/javaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-ext_1_0.xsd"
+  version="1.0"
+>
+  <reload-interval value="3"/>
+</web-ext>

--- a/spec/fixtures/ibm-web-ext.xml
+++ b/spec/fixtures/ibm-web-ext.xml
@@ -1,0 +1,8 @@
+<web-ext
+  xmlns="http://websphere.ibm.com/xml/ns/javaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-ext_1_0.xsd"
+  version="1.0"
+>
+  <context-root uri="myContext"/>
+</web-ext>

--- a/spec/liberty_buildpack/container/web_xml_ext_spec.rb
+++ b/spec/liberty_buildpack/container/web_xml_ext_spec.rb
@@ -1,0 +1,50 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2015 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+require 'spec_helper'
+require 'logging_helper'
+require 'liberty_buildpack/container/web_xml_ext'
+
+module LibertyBuildpack::Container
+
+  describe WebXmlExt do
+    include_context 'logging_helper'
+
+    it 'should handle file that does not exist' do
+      ibm_web_xml = LibertyBuildpack::Container::WebXmlExt.read('doesnotexist')
+      expect(ibm_web_xml).to be_nil
+    end
+
+    it 'should handle malformed file' do
+      ibm_web_xml = LibertyBuildpack::Container::WebXmlExt.read('spec/fixtures/ibm-web-ext-bad.xml')
+      expect(ibm_web_xml).to be_nil
+    end
+
+    it 'should handle file without context-root' do
+      ibm_web_xml = LibertyBuildpack::Container::WebXmlExt.read('spec/fixtures/ibm-web-ext-no-context.xml')
+      expect(ibm_web_xml).not_to be_nil
+      expect(ibm_web_xml.get_context_root).to be_nil
+    end
+
+    it 'should handle file with context-root' do
+      ibm_web_xml = LibertyBuildpack::Container::WebXmlExt.read('spec/fixtures/ibm-web-ext.xml')
+      expect(ibm_web_xml).not_to be_nil
+      expect(ibm_web_xml.get_context_root).to eq('myContext')
+    end
+
+  end
+
+end

--- a/spec/liberty_buildpack/framework/spring_auto_reconfiguration_spec.rb
+++ b/spec/liberty_buildpack/framework/spring_auto_reconfiguration_spec.rb
@@ -15,11 +15,13 @@
 # limitations under the License.
 
 require 'spec_helper'
+require 'logging_helper'
 require 'liberty_buildpack/framework/spring_auto_reconfiguration'
 
 module LibertyBuildpack::Framework
 
   describe SpringAutoReconfiguration do
+    include_context 'logging_helper'
 
     SPRING_AUTO_RECONFIGURATION_VERSION = LibertyBuildpack::Util::TokenizedVersion.new('0.6.8')
 
@@ -27,16 +29,6 @@ module LibertyBuildpack::Framework
 
     let(:application_cache) { double('ApplicationCache') }
     let(:web_xml_modifier) { double('WebXmlModifier') }
-
-    before do
-      $stdout = StringIO.new
-      $stderr = StringIO.new
-    end
-
-    after do
-      $stdout = STDOUT
-      $stderr = STDERR
-    end
 
     it 'should detect with Spring JAR in WEB-INF' do
       LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item).and_return(SPRING_AUTO_RECONFIGURATION_DETAILS)
@@ -170,7 +162,7 @@ module LibertyBuildpack::Framework
         LibertyBuildpack::Util::ApplicationCache.stub(:new).and_return(application_cache)
         application_cache.stub(:get).with('test-uri').and_yield(File.open('spec/fixtures/wlp-stub.jar'))
 
-        liberty = LibertyBuildpack::Container::Liberty.new(
+        LibertyBuildpack::Container::Liberty.new(
         app_dir: root,
         lib_directory: lib_directory,
         configuration: {},
@@ -184,22 +176,19 @@ module LibertyBuildpack::Framework
         configuration: {}
         ).compile
 
-        apps = liberty.apps
-        apps.each do |app|
-          lib = File.join(app, 'WEB-INF', 'lib')
-          test_jar_1 = File.join lib, 'test-jar-1.jar'
-          test_jar_2 = File.join lib, 'test-jar-2.jar'
-          test_text = File.join lib, 'test-text.txt'
-          expect(File.exists?(test_jar_1)).to eq(true)
-          expect(File.symlink?(test_jar_1)).to eq(true)
-          expect(File.readlink(test_jar_1)).to eq(Pathname.new(File.join(lib_directory, 'test-jar-1.jar')).relative_path_from(Pathname.new(lib)).to_s)
+        lib = File.join(war_file, 'WEB-INF', 'lib')
+        test_jar_1 = File.join lib, 'test-jar-1.jar'
+        test_jar_2 = File.join lib, 'test-jar-2.jar'
+        test_text = File.join lib, 'test-text.txt'
+        expect(File.exists?(test_jar_1)).to eq(true)
+        expect(File.symlink?(test_jar_1)).to eq(true)
+        expect(File.readlink(test_jar_1)).to eq(Pathname.new(File.join(lib_directory, 'test-jar-1.jar')).relative_path_from(Pathname.new(lib)).to_s)
 
-          expect(File.exists?(test_jar_2)).to eq(true)
-          expect(File.symlink?(test_jar_2)).to eq(true)
-          expect(File.readlink(test_jar_2)).to eq(Pathname.new(File.join(lib_directory, 'test-jar-2.jar')).relative_path_from(Pathname.new(lib)).to_s)
+        expect(File.exists?(test_jar_2)).to eq(true)
+        expect(File.symlink?(test_jar_2)).to eq(true)
+        expect(File.readlink(test_jar_2)).to eq(Pathname.new(File.join(lib_directory, 'test-jar-2.jar')).relative_path_from(Pathname.new(lib)).to_s)
 
-          expect(File.exists?(test_text)).to eq(false)
-        end
+        expect(File.exists?(test_text)).to eq(false)
       end
     end
 
@@ -219,7 +208,7 @@ module LibertyBuildpack::Framework
         LibertyBuildpack::Util::ApplicationCache.stub(:new).and_return(application_cache)
         application_cache.stub(:get).with('test-uri').and_yield(File.open('spec/fixtures/wlp-stub.jar'))
 
-        liberty = LibertyBuildpack::Container::Liberty.new(
+        LibertyBuildpack::Container::Liberty.new(
         app_dir: root,
         lib_directory: lib_directory,
         configuration: {},
@@ -233,24 +222,20 @@ module LibertyBuildpack::Framework
         configuration: {}
         ).compile
 
-        apps = liberty.apps
-        expect(apps.size).to eq(1)
-        apps.each do |app|
-          lib = File.join(app, 'WEB-INF', 'lib')
-          test_jar_1 = File.join lib, 'test-jar-1.jar'
-          test_jar_2 = File.join lib, 'test-jar-2.jar'
-          test_text = File.join lib, 'test-text.txt'
+        lib = File.join(app_dir, 'WEB-INF', 'lib')
+        test_jar_1 = File.join lib, 'test-jar-1.jar'
+        test_jar_2 = File.join lib, 'test-jar-2.jar'
+        test_text = File.join lib, 'test-text.txt'
 
-          expect(File.exists?(test_jar_1)).to eq(true)
-          expect(File.symlink?(test_jar_1)).to eq(true)
-          expect(File.readlink(test_jar_1)).to eq(Pathname.new(File.join(lib_directory, 'test-jar-1.jar')).relative_path_from(Pathname.new(lib)).to_s)
+        expect(File.exists?(test_jar_1)).to eq(true)
+        expect(File.symlink?(test_jar_1)).to eq(true)
+        expect(File.readlink(test_jar_1)).to eq(Pathname.new(File.join(lib_directory, 'test-jar-1.jar')).relative_path_from(Pathname.new(lib)).to_s)
 
-          expect(File.exists?(test_jar_2)).to eq(true)
-          expect(File.symlink?(test_jar_2)).to eq(true)
-          expect(File.readlink(test_jar_2)).to eq(Pathname.new(File.join(lib_directory, 'test-jar-2.jar')).relative_path_from(Pathname.new(lib)).to_s)
+        expect(File.exists?(test_jar_2)).to eq(true)
+        expect(File.symlink?(test_jar_2)).to eq(true)
+        expect(File.readlink(test_jar_2)).to eq(Pathname.new(File.join(lib_directory, 'test-jar-2.jar')).relative_path_from(Pathname.new(lib)).to_s)
 
-          expect(File.exists?(test_text)).to eq(false)
-        end
+        expect(File.exists?(test_text)).to eq(false)
       end
     end
 


### PR DESCRIPTION
Two changes:
- If provided, use context-root from ibm-web-ext.xml for web applications.
- Refactor the liberty.apps function as it was primarily used by tests and nothing else (and remove tests that only tested that function).
