### PR TITLE
Provide platform information to JRebel

### DIFF
--- a/lib/liberty_buildpack/container/container_utils.rb
+++ b/lib/liberty_buildpack/container/container_utils.rb
@@ -70,7 +70,7 @@ module LibertyBuildpack::Container
         if File.exists? '/usr/bin/unzip'
           system "unzip -qqo '#{file}'"
         else
-          system "jar xf '#{file}'"
+          system "jar xf \"#{file}\""
         end
       end
     end
@@ -84,9 +84,9 @@ module LibertyBuildpack::Container
       file = File.expand_path(file)
       Dir.chdir (dir) do
         if File.exists? '/usr/bin/zip'
-          system "zip -rq #{file} *"
+          system "zip -rq '#{file}' *"
         else
-          system "jar cf #{file} *"
+          system "jar cf \"#{file}\" *"
         end
       end
     end

--- a/lib/liberty_buildpack/framework/jrebel_agent.rb
+++ b/lib/liberty_buildpack/framework/jrebel_agent.rb
@@ -98,6 +98,7 @@ module LibertyBuildpack::Framework
       @java_opts << '-Drebel.remoting_plugin=true'
       @java_opts << '-Drebel.log=true'
       @java_opts << "-Drebel.log.file=#{jr_log}"
+      @java_opts << '-Drebel.cloud.platform=cloudfoundry/ibm-websphere-liberty-buildpack'
 
       unless openjdk?
         @java_opts << '-Drebel.redefine_class=false'

--- a/spec/liberty_buildpack/framework/jrebel_agent_spec.rb
+++ b/spec/liberty_buildpack/framework/jrebel_agent_spec.rb
@@ -188,6 +188,7 @@ module LibertyBuildpack::Framework
         expect(java_opts).to include('-Drebel.redefine_class=false')
         expect(java_opts).to include('-Drebel.log=true')
         expect(java_opts).to include('-Drebel.log.file=./../logs/jrebel.log')
+        expect(java_opts).to include('-Drebel.cloud.platform=cloudfoundry/ibm-websphere-liberty-buildpack')
       end
 
       it 'should return command line options for a valid service in a default container with openjdk',
@@ -199,6 +200,7 @@ module LibertyBuildpack::Framework
         expect(java_opts).not_to include('-Drebel.redefine_class=false')
         expect(java_opts).to include('-Drebel.log=true')
         expect(java_opts).to include('-Drebel.log.file=./../logs/jrebel.log')
+        expect(java_opts).to include('-Drebel.cloud.platform=cloudfoundry/ibm-websphere-liberty-buildpack')
       end
 
       it 'should return command line options for a valid service in a container with an adjusted relative location',
@@ -212,6 +214,7 @@ module LibertyBuildpack::Framework
         expect(java_opts).to include('-Drebel.redefine_class=false')
         expect(java_opts).to include('-Drebel.log=true')
         expect(java_opts).to include('-Drebel.log.file=../../../../logs/jrebel.log')
+        expect(java_opts).to include('-Drebel.cloud.platform=cloudfoundry/ibm-websphere-liberty-buildpack')
       end
     end # end of release
   end


### PR DESCRIPTION
* Pass an additional property to JRebel so that it knows that it is
  running as part of a Cloud Foundry buildpack.
* Properly quote command arguments in container_utils.rb to be able to
  run tests on Windows.