### PR TITLE
Handle simpler and invalid values for config overrides

### DIFF
--- a/lib/liberty_buildpack/util/configuration_utils.rb
+++ b/lib/liberty_buildpack/util/configuration_utils.rb
@@ -42,17 +42,8 @@ module LibertyBuildpack::Util
         file = CONFIG_DIRECTORY + "#{identifier}.yml"
 
         if file.exist?
-          configuration = YAML.load_file(file)
-          logger.debug { "Configuration from #{file}: #{configuration}" } if should_log
-
           user_provided = ENV[environment_variable_name(identifier)]
-
-          if user_provided
-            YAML.load(user_provided).each do |new_prop|
-              configuration = do_merge(configuration, new_prop, should_log)
-            end
-            logger.debug { "Configuration from #{file} modified with: #{user_provided}" } if should_log
-          end
+          configuration = load_configuration(file, user_provided, should_log)
         else
           logger.debug { "No configuration file #{file} found" } if should_log
         end
@@ -65,6 +56,27 @@ module LibertyBuildpack::Util
       CONFIG_DIRECTORY = Pathname.new(File.expand_path('../../../config', File.dirname(__FILE__))).freeze
 
       ENVIRONMENT_VARIABLE_PATTERN = 'JBP_CONFIG_'
+
+      def load_configuration(file, user_provided, should_log)
+        configuration = YAML.load_file(file)
+        logger.debug { "Configuration from #{file}: #{configuration}" } if should_log
+
+        if user_provided
+          user_provided_value = YAML.load(user_provided)
+          if user_provided_value.is_a?(Hash)
+            configuration = do_merge(configuration, user_provided_value, should_log)
+          elsif user_provided_value.is_a?(Array)
+            user_provided_value.each do |new_prop|
+              configuration = do_merge(configuration, new_prop, should_log)
+            end
+          else
+            fail "User configuration value is not valid: #{user_provided_value}"
+          end
+          logger.debug { "Configuration from #{file} modified with: #{user_provided}" } if should_log
+        end
+
+        configuration
+      end
 
       def do_merge(hash_v1, hash_v2, should_log)
         hash_v2.each do |key, value|

--- a/spec/liberty_buildpack/util/configuration_utils_spec.rb
+++ b/spec/liberty_buildpack/util/configuration_utils_spec.rb
@@ -34,12 +34,14 @@ describe LibertyBuildpack::Util::ConfigurationUtils do
     before do
       allow_any_instance_of(Pathname).to receive(:exist?).and_return(true)
       allow(YAML).to receive(:load_file).and_return('foo' => { 'one' => '1', 'two' => 2 },
-                                                    'bar' => { 'alpha' => { 'one' => 'cat', 'two' => 'dog' } })
+                                                    'bar' => { 'alpha' => { 'one' => 'cat', 'two' => 'dog' } },
+                                                    'version' => '1.7.1')
     end
 
     it 'load configuration file' do
       expect(described_class.load('test')).to eq('foo' => { 'one' => '1', 'two' => 2 },
-                                                 'bar' => { 'alpha' => { 'one' => 'cat', 'two' => 'dog' } })
+                                                 'bar' => { 'alpha' => { 'one' => 'cat', 'two' => 'dog' } },
+                                                 'version' => '1.7.1')
     end
 
     context do
@@ -51,7 +53,34 @@ describe LibertyBuildpack::Util::ConfigurationUtils do
       it 'overlays matching environment variables' do
 
         expect(described_class.load('test')).to eq('foo' => { 'one' => '1', 'two' => 2 },
-                                                   'bar' => { 'alpha' => { 'one' => 3, 'two' => 'dog' } })
+                                                   'bar' => { 'alpha' => { 'one' => 3, 'two' => 'dog' } },
+                                                   'version' => '1.7.1')
+      end
+
+    end
+
+    context do
+
+      let(:environment) do
+        { 'JBP_CONFIG_TEST' => 'version: 1.8.+' }
+      end
+
+      it 'overlays simple matching environment variable' do
+        expect(described_class.load('test')).to eq('foo' => { 'one' => '1', 'two' => 2 },
+                                                   'bar' => { 'alpha' => { 'one' => 'cat', 'two' => 'dog' } },
+                                                   'version' => '1.8.+')
+      end
+
+    end
+
+    context do
+
+      let(:environment) do
+        { 'JBP_CONFIG_TEST' => 'version 1.8.+' }
+      end
+
+      it 'raises an exception when invalid override value is specified' do
+        expect { described_class.load('test') }.to raise_error(/User configuration value is not valid/)
       end
 
     end


### PR DESCRIPTION
Two key changes:
 1. Handle simpler overrides (no need for array for single overrides). For example instead of `JBP_CONFIG_OPEN_JDK_JRE '[version: 1.7.0_+]'` handle  `JBP_CONFIG_OPEN_JDK_JRE 'version: 1.7.0_+'`
 1. Handle invalid values better. For example, for invalid input such as `JBP_CONFIG_OPEN_JDK_JRE 'version 1.7.0_+'` generate a nicer error message instead of Ruby errors (e.g. NoMethodError).
