### PR TITLE
ensure id='defaultHttpEndpoint' attribute is added to httpEndpoint

### DIFF
--- a/lib/liberty_buildpack/container/liberty.rb
+++ b/lib/liberty_buildpack/container/liberty.rb
@@ -363,6 +363,7 @@ module LibertyBuildpack::Container
 
       if endpoints.empty?
         endpoint = REXML::Element.new('httpEndpoint', server_xml_doc.root)
+        endpoint.add_attribute('id', 'defaultHttpEndpoint')
       else
         endpoint = endpoints[0]
         endpoints.drop(1).each { |element| element.parent.delete_element(element) }

--- a/spec/liberty_buildpack/container/liberty_spec.rb
+++ b/spec/liberty_buildpack/container/liberty_spec.rb
@@ -948,6 +948,8 @@ module LibertyBuildpack::Container
           endpoints = REXML::XPath.match(REXML::Document.new(server_xml_contents), '/server/httpEndpoint')
           expect(endpoints.size).to eq(1)
           attributes = endpoints[0].attributes
+          expect(attributes).to have_key('id')
+          expect(attributes['id']).to eq('defaultHttpEndpoint')
           expect(attributes).to have_key('httpPort')
           expect(attributes).not_to have_key('httpsPort')
           expect(attributes).to have_key('host')


### PR DESCRIPTION
Ensure id='defaultHttpEndpoint' attribute is added to httpEndpoint when generating a new entry.
