### PR TITLE
Control CDI 1.2 annotation scanning

### DIFF
--- a/config/liberty.yml
+++ b/config/liberty.yml
@@ -23,6 +23,9 @@ liberty_repository_properties:
   useRepository: true
 
 app_archive:
+ # Scan archives that do not contain beans.xml for bean-definition annotations (cdi 1.2)
+ implicit_cdi: false
+ # Default features
  features: 
  - jsf-2.0
  - jsp-2.2

--- a/docs/container-liberty.md
+++ b/docs/container-liberty.md
@@ -5,9 +5,10 @@ The Liberty Container runs Java EE 6 and 7 applications on [IBM's WebSphere Appl
   <tr>
     <td><strong>Detection Criterion</strong></td>
     <td><ul>
-	<li>Existence of a <tt>WEB-INF/</tt> folder in the application directory and <a href="java-main.md">Java Main</a> is not detected.</li>
-	<li>Existence of a <tt>META-INF/</tt> folder in the application directory and <a href="java-main.md">Java Main</a> is not detected.</li>
-	<li>Existence of a <tt>server.xml</tt> file in the application directory.</li>
+	<li>Existence of a <tt>WEB-INF/</tt> folder in the application directory and <a href="java-main.md">Java Main</a> is not detected, or</li>
+	<li>Existence of a <tt>META-INF/</tt> folder in the application directory and <a href="java-main.md">Java Main</a> is not detected, or</li>
+	<li>Existence of a <tt>server.xml</tt> file in the application directory, or</li>
+	<li>Existence of a <tt>wlp/usr/servers/*/server.xml</tt> file in the application directory.</li>
     </ul></td>
   </tr>
   <tr>
@@ -53,10 +54,13 @@ liberty_repository_properties:
 
 #### Default configuration 
 
-The buildpack provides a default `server.xml` configuration when deploying WAR or EAR files. The configuration contains a list of Liberty features that are enabled by default. This set of features can be adjusted by modifying the `features` setting.
+The buildpack provides a default `server.xml` configuration when deploying WAR or EAR files. That default configuration is populated with a list of Liberty features based on the `["app_archive"]["features"]` setting. The `["app_archive"]["implicit_cdi"]` setting controls whether archives that do not contain the `beans.xml` file are scanned for CDI annotations. 
 
 ```yaml
 app_archive:
+ # Scan archives that do not contain beans.xml for bean-definition annotations (cdi 1.2)
+ implicit_cdi: false
+ # Default features
  features: 
  - jsf-2.0
  - jsp-2.2

--- a/lib/liberty_buildpack/container/liberty.rb
+++ b/lib/liberty_buildpack/container/liberty.rb
@@ -356,6 +356,11 @@ module LibertyBuildpack::Container
       application.attributes['type'] = myapp_type
       application.attributes['context-root'] = get_context_root || '/'
 
+      # configure CDI 1.2 implicit bean archive scanning
+      cdi = REXML::Element.new('cdi12', server_xml_doc.root)
+      scan = default_config.nil? || default_config['implicit_cdi'].nil? ? false : default_config['implicit_cdi']
+      cdi.add_attribute('enableImplicitBeanArchives', scan)
+
       # add common settings
       update_server_xml_common(server_xml_doc, true)
 


### PR DESCRIPTION
As part of Java EE 7/CDI 1.2, beans.xml is no longer necessary to enable DI support. However, that also means that applications might take longer to start since CDI will now scan all classes for annotations. 
The changes in this pull request introduce a configuration option (`implicit_cdi`) to control this scanning. By default, in order to improve performance, scanning of the archives without beans.xml will not be performed. This configuration option only applies when deploying WAR or EAR files. It does not apply when deploying server directories or packaged servers.