### PR TITLE
set WLP_SKIP_MAXPERMSIZE to disable passing XX:MaxPermSize

### DIFF
--- a/lib/liberty_buildpack/container/liberty.rb
+++ b/lib/liberty_buildpack/container/liberty.rb
@@ -109,17 +109,20 @@ module LibertyBuildpack::Container
     #
     # @return [String] the command to run the application.
     def release
+      jvm_options
+
       server_dir = ' wlp/usr/servers/' << server_name << '/'
       runtime_vars_file =  server_dir + 'runtime-vars.xml'
       create_vars_string = File.join(LIBERTY_HOME, 'create_vars.rb') << runtime_vars_file << ' &&'
+      skip_maxpermsize_string = ContainerUtils.space('WLP_SKIP_MAXPERMSIZE=true')
       java_home_string = ContainerUtils.space("JAVA_HOME=\"$PWD/#{@java_home}\"")
       wlp_user_dir_string = ContainerUtils.space('WLP_USER_DIR="$PWD/wlp/usr"')
-      start_script_string = ContainerUtils.space(File.join(LIBERTY_HOME, 'bin', 'server'))
-      start_script_string << ContainerUtils.space('run')
-      jvm_options
-      server_name_string = ContainerUtils.space(server_name)
+      server_script_string = ContainerUtils.space(File.join(LIBERTY_HOME, 'bin', 'server'))
+
+      start_command = "#{create_vars_string}#{skip_maxpermsize_string}#{java_home_string}#{wlp_user_dir_string}#{server_script_string} run #{server_name}"
       move_app
-      "#{create_vars_string}#{java_home_string}#{wlp_user_dir_string}#{start_script_string}#{server_name_string}"
+
+      start_command
     end
 
     private

--- a/spec/liberty_buildpack/container/liberty_spec.rb
+++ b/spec/liberty_buildpack/container/liberty_spec.rb
@@ -1532,7 +1532,7 @@ module LibertyBuildpack::Container
             license_ids: {}
           ).release
 
-          expect(command).to eq(".liberty/create_vars.rb wlp/usr/servers/defaultServer/runtime-vars.xml && JAVA_HOME=\"$PWD/#{test_java_home}\" WLP_USER_DIR=\"$PWD/wlp/usr\" .liberty/bin/server run defaultServer")
+          expect(command).to eq(".liberty/create_vars.rb wlp/usr/servers/defaultServer/runtime-vars.xml && WLP_SKIP_MAXPERMSIZE=true JAVA_HOME=\"$PWD/#{test_java_home}\" WLP_USER_DIR=\"$PWD/wlp/usr\" .liberty/bin/server run defaultServer")
         end
       end
 
@@ -1550,7 +1550,7 @@ module LibertyBuildpack::Container
             license_ids: {}
           ).release
 
-          expect(command).to eq(".liberty/create_vars.rb wlp/usr/servers/defaultServer/runtime-vars.xml && JAVA_HOME=\"$PWD/#{test_java_home}\" WLP_USER_DIR=\"$PWD/wlp/usr\" .liberty/bin/server run defaultServer")
+          expect(command).to eq(".liberty/create_vars.rb wlp/usr/servers/defaultServer/runtime-vars.xml && WLP_SKIP_MAXPERMSIZE=true JAVA_HOME=\"$PWD/#{test_java_home}\" WLP_USER_DIR=\"$PWD/wlp/usr\" .liberty/bin/server run defaultServer")
         end
       end
 
@@ -1568,7 +1568,7 @@ module LibertyBuildpack::Container
             license_ids: {}
           ).release
 
-          expect(command).to eq(".liberty/create_vars.rb wlp/usr/servers/myServer/runtime-vars.xml && JAVA_HOME=\"$PWD/#{test_java_home}\" WLP_USER_DIR=\"$PWD/wlp/usr\" .liberty/bin/server run myServer")
+          expect(command).to eq(".liberty/create_vars.rb wlp/usr/servers/myServer/runtime-vars.xml && WLP_SKIP_MAXPERMSIZE=true JAVA_HOME=\"$PWD/#{test_java_home}\" WLP_USER_DIR=\"$PWD/wlp/usr\" .liberty/bin/server run myServer")
         end
       end
 
@@ -1586,7 +1586,7 @@ module LibertyBuildpack::Container
             license_ids: {}
           ).release
 
-          expect(command).to eq(".liberty/create_vars.rb wlp/usr/servers/defaultServer/runtime-vars.xml && JAVA_HOME=\"$PWD/#{test_java_home}\" WLP_USER_DIR=\"$PWD/wlp/usr\" .liberty/bin/server run defaultServer")
+          expect(command).to eq(".liberty/create_vars.rb wlp/usr/servers/defaultServer/runtime-vars.xml && WLP_SKIP_MAXPERMSIZE=true JAVA_HOME=\"$PWD/#{test_java_home}\" WLP_USER_DIR=\"$PWD/wlp/usr\" .liberty/bin/server run defaultServer")
         end
       end
 


### PR DESCRIPTION
The Liberty server script automatically passes -XX:MaxPermSize=256m to the JVM. Since this value is calculated by the buildpack (based on memory settings) and since the MaxPermSize option is not supported on OpenJDK 8, we need to set  WLP_SKIP_MAXPERMSIZE variable to prevent Liberty from setting it.
 