### PR TITLE
#246: Mark .bin files executable in admin cache

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -96,6 +96,7 @@ task :package, [:zipfile, :hosts, :version] do |t, args|
     # Fix file permissions
     system("find #{dest} -type f -exec chmod a+r {} \\;")
     system("find #{dest} -type d -exec chmod a+rx {} \\;")
+    system("find #{dest} -type f -name '*.bin.cached' -exec chmod a+x {} \\;")
     system("chmod a+rx #{dest}/bin/*")
     system("cd #{dest} && zip -r #{zipfile} -x@.package-exclude .")
   end

--- a/lib/liberty_buildpack/jre/ibmjdk.rb
+++ b/lib/liberty_buildpack/jre/ibmjdk.rb
@@ -135,10 +135,8 @@ module LibertyBuildpack::Jre
           response_file.puts("USER_INSTALL_DIR=#{java_home}")
           response_file.close
 
-          File.chmod(0755, file.path)
+          File.chmod(0755, file.path) unless File.executable?(file.path)
           system "#{file.path} -i silent -f #{response_file.path} 2>&1"
-
-          response_file.unlink
       else
         system "tar xzf #{file.path} -C #{java_home} --strip 1 2>&1"
       end

--- a/spec/liberty_buildpack/jre/ibmjdk_spec.rb
+++ b/spec/liberty_buildpack/jre/ibmjdk_spec.rb
@@ -165,6 +165,10 @@ module LibertyBuildpack::Jre
 
     end # end of shared tests for IBMJDK v7 release
 
+    context 'IBMJDK Service Release 1.7.1' do
+      it_behaves_like 'IBMJDK v7', '1.7.1'
+    end
+
   end
 
 end


### PR DESCRIPTION
Mark any .bin files executable in the admin cache. That will avoid making an additional copy of the IBM JRE just to set the proper executable permission.
