### PR TITLE
Disable class sharing

### DIFF
--- a/lib/liberty_buildpack/jre/ibmjdk.rb
+++ b/lib/liberty_buildpack/jre/ibmjdk.rb
@@ -102,6 +102,7 @@ module LibertyBuildpack::Jre
     def release
       @java_opts.concat memory(@configuration)
       @java_opts.concat default_dump_opts
+      @java_opts << '-Xshareclasses:none'
       @java_opts << "-Xdump:tool:events=systhrow,filter=java/lang/OutOfMemoryError,request=serial+exclusive,exec=#{@common_paths.diagnostics_directory}/#{KILLJAVA_FILE_NAME}"
     end
 
@@ -188,10 +189,6 @@ module LibertyBuildpack::Jre
       default_options.push "-Xdump:snap:defaults:file=#{@common_paths.dump_directory}/Snap.%Y%m%d.%H%M%S.%pid.%seq.trc"
       default_options.push '-Xdump:heap+java+snap:events=user'
       default_options
-    end
-
-    def pre_8
-      @version < LibertyBuildpack::Util::TokenizedVersion.new('1.8.0')
     end
 
     def copy_killjava_script

--- a/spec/liberty_buildpack/jre/ibmjdk_spec.rb
+++ b/spec/liberty_buildpack/jre/ibmjdk_spec.rb
@@ -143,6 +143,7 @@ module LibertyBuildpack::Jre
 
         it 'should add default dump options that output data to the common dumps directory, if enabled' do
           expect(released).to include('-Xdump:none',
+                                      '-Xshareclasses:none',
                                       '-Xdump:heap:defaults:file=./../dumps/heapdump.%Y%m%d.%H%M%S.%pid.%seq.phd',
                                       '-Xdump:java:defaults:file=./../dumps/javacore.%Y%m%d.%H%M%S.%pid.%seq.txt',
                                       '-Xdump:snap:defaults:file=./../dumps/Snap.%Y%m%d.%H%M%S.%pid.%seq.trc',


### PR DESCRIPTION
By default, Liberty runtime enables shared class cache feature of IBM JRE. However, in Cloud Foundry, every time an application is started, a new file system is created for the application. That means, that the class cache is never really used and in fact it may incur additional overhead in saving the cache to disk. So, it makes sense to disable it.
