### PR TITLE
Synchronize repository module

### DIFF
--- a/config/openjdk.yml
+++ b/config/openjdk.yml
@@ -18,7 +18,7 @@
 # If Java 8 is selected, the 'metaspace' option will be used. 
 # Please see the documentation for more detail.
 ---
-repository_root: "https://download.run.pivotal.io/openjdk/lucid/x86_64"
+repository_root: ! '{default.repository.root}/openjdk/{platform}/{architecture}'
 version: 1.8.+
 memory_sizes:
   metaspace: 64m..

--- a/config/repository.yml
+++ b/config/repository.yml
@@ -1,5 +1,5 @@
 # IBM WebSphere Application Server Liberty Buildpack
-# Copyright 2014 the original author or authors.
+# Copyright 2013-2015 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Service configuration
+# Repository configuration
 ---
-version: 3.+
-repository_root: ! '{default.repository.root}/new-relic'
+default_repository_root: https://download.run.pivotal.io

--- a/config/springautoreconfiguration.yml
+++ b/config/springautoreconfiguration.yml
@@ -18,5 +18,5 @@
 # avoid conflicts.
 ---
 version: 1.+
-repository_root: "https://download.run.pivotal.io/auto-reconfiguration"
+repository_root: ! '{default.repository.root}/auto-reconfiguration'
 enabled: true

--- a/lib/liberty_buildpack/container/liberty.rb
+++ b/lib/liberty_buildpack/container/liberty.rb
@@ -743,13 +743,17 @@ module LibertyBuildpack::Container
     # Returns the version, artifact uri, and license of the requested item in the index file
     def self.find_liberty_item(app_dir, configuration)
       if server_xml(app_dir) || web_inf(app_dir) || meta_inf(app_dir)
-        version, config_uri, license = LibertyBuildpack::Repository::ConfiguredItem.find_item(configuration) do |candidate_version|
+        version, entry = LibertyBuildpack::Repository::ConfiguredItem.find_item(configuration) do |candidate_version|
           fail "Malformed Liberty version #{candidate_version}: too many version components" if candidate_version[4]
         end
+        if entry.include?('uri') && entry.include?('license')
+          return version, entry['uri'], entry['license']
+        else
+          return version, entry, nil
+        end
       else
-        version = config_uri = nil
+        return nil, nil, nil
       end
-      return version, config_uri, license
     rescue => e
       raise RuntimeError, "Liberty container error: #{e.message}", e.backtrace
     end

--- a/lib/liberty_buildpack/jre/ibmjdk.rb
+++ b/lib/liberty_buildpack/jre/ibmjdk.rb
@@ -146,7 +146,12 @@ module LibertyBuildpack::Jre
     end
 
     def self.find_ibmjdk(configuration)
-      LibertyBuildpack::Repository::ConfiguredItem.find_item(configuration)
+      version, entry = LibertyBuildpack::Repository::ConfiguredItem.find_item(configuration)
+      if entry.include?('uri') && entry.include?('license')
+        return version, entry['uri'], entry['license']
+      else
+        return version, entry
+      end
     rescue => e
       raise RuntimeError, "IBM JRE error: #{e.message}", e.backtrace
     end

--- a/lib/liberty_buildpack/repository/configured_item.rb
+++ b/lib/liberty_buildpack/repository/configured_item.rb
@@ -1,6 +1,6 @@
 # Encoding: utf-8
 # IBM WebSphere Application Server Liberty Buildpack
-# Copyright 2013 the original author or authors.
+# Copyright 2013-2015 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,47 +18,65 @@ require 'liberty_buildpack/repository'
 require 'liberty_buildpack/repository/repository_index'
 require 'liberty_buildpack/util/tokenized_version'
 
-module LibertyBuildpack::Repository
+module LibertyBuildpack
+  module Repository
 
-  # A class encapsulating details of a file stored in a versioned repository.
-  class ConfiguredItem
+    # A class encapsulating details of a file stored in a versioned repository.
+    class ConfiguredItem
 
-    # Finds an instance of the file based on the configuration.
-    #
-    # @param [Hash] configuration the configuration
-    # @option configuration [String] :repository_root the root directory of the repository
-    # @option configuration [String] :version the version of the file to resolve
-    # @param [Block, nil] version_validator an optional version validation block
-    # @return [String] the URI of the chosen version of the file
-    # @return [LibertyBuildpack::Util::TokenizedVersion] the chosen version of the file
-    def self.find_item(configuration, &version_validator)
-      repository_root = ConfiguredItem.repository_root(configuration)
-      version = ConfiguredItem.version(configuration)
-      yield version if block_given?
-      version_validator.call(version) if version_validator
-      index = ConfiguredItem.index(repository_root)
-      index.find_item version
+      private_class_method :new
+
+      class << self
+
+        # Finds an instance of the file based on the configuration and wraps any exceptions
+        # to identify the component.
+        #
+        # @param [String] component_name the name of the component
+        # @param [Hash] configuration the configuration
+        # @option configuration [String] :repository_root the root directory of the repository
+        # @option configuration [String] :version the version of the file to resolve
+        # @yield [Block] optional version_validator to yield to
+        # @return [String] the URI of the chosen version of the file
+        # @return [LibertyBuildpack::Util::TokenizedVersion] the chosen version of the file
+        def find_item(component_name = nil, configuration)
+          repository_root = repository_root(configuration)
+          version         = version(configuration)
+
+          yield version if block_given?
+
+          index = index(repository_root)
+          index.find_item version
+        rescue => e
+          raise RuntimeError, "#{component_name} error: #{e.message}", e.backtrace unless component_name.nil?
+        end
+
+        private
+
+        KEY_REPOSITORY_ROOT = 'repository_root'.freeze
+
+        KEY_VERSION = 'version'.freeze
+
+        private_constant :KEY_REPOSITORY_ROOT, :KEY_VERSION
+
+        def index(repository_root)
+          RepositoryIndex.new(repository_root)
+        end
+
+        def repository_root(configuration)
+          unless configuration.key? KEY_REPOSITORY_ROOT
+            fail "A repository root must be specified as a key-value pair of '#{KEY_REPOSITORY_ROOT}'' to the URI of the repository."
+          end
+
+          configuration[KEY_REPOSITORY_ROOT]
+        end
+
+        def version(configuration)
+          LibertyBuildpack::Util::TokenizedVersion.new(configuration[KEY_VERSION])
+        end
+
+      end
+
     end
 
-    private
-
-      KEY_REPOSITORY_ROOT = 'repository_root'.freeze
-
-      KEY_VERSION = 'version'.freeze
-
-      def self.index(repository_root)
-        RepositoryIndex.new(repository_root)
-      end
-
-      def self.repository_root(configuration)
-        raise "A repository root must be specified as a key-value pair of '#{KEY_REPOSITORY_ROOT}'' to the URI of the repository." unless configuration.has_key? KEY_REPOSITORY_ROOT
-        configuration[KEY_REPOSITORY_ROOT]
-      end
-
-      def self.version(configuration)
-        LibertyBuildpack::Util::TokenizedVersion.new(configuration[KEY_VERSION])
-      end
-
   end
-
 end

--- a/spec/liberty_buildpack/container/liberty_spec.rb
+++ b/spec/liberty_buildpack/container/liberty_spec.rb
@@ -27,7 +27,7 @@ module LibertyBuildpack::Container
 
     LIBERTY_VERSION = LibertyBuildpack::Util::TokenizedVersion.new('8.5.5')
     LIBERTY_SINGLE_DOWNLOAD_URI = 'test-liberty-uri.tar.gz'.freeze # end of URI (here ".tar.gz") is significant in liberty container code
-    LIBERTY_DETAILS = [LIBERTY_VERSION, LIBERTY_SINGLE_DOWNLOAD_URI, 'spec/fixtures/license.html']
+    LIBERTY_DETAILS = [LIBERTY_VERSION, { 'uri' => LIBERTY_SINGLE_DOWNLOAD_URI, 'license' => 'spec/fixtures/license.html' }]
     DISABLE_2PC_JAVA_OPT_REGEX = '-Dcom.ibm.tx.jta.disable2PC=true'.freeze
 
     let(:application_cache) { double('ApplicationCache') }
@@ -474,7 +474,7 @@ module LibertyBuildpack::Container
         Dir.mktmpdir do |root|
           Dir.mkdir File.join(root, 'WEB-INF')
 
-          LIBERTY_OS_DETAILS = [LIBERTY_VERSION, 'wlp-developers.jar', 'spec/fixtures/license.html']
+          LIBERTY_OS_DETAILS = [LIBERTY_VERSION, { 'uri' => 'wlp-developers.jar', 'license' => 'spec/fixtures/license.html' }]
 
           LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
           .and_return(LIBERTY_OS_DETAILS)
@@ -518,7 +518,7 @@ module LibertyBuildpack::Container
             file.write('test file that should still exist after overlay')
           end
 
-          LIBERTY_OS_DETAILS = [LIBERTY_VERSION, 'wlp-developers.jar', 'spec/fixtures/license.html']
+          LIBERTY_OS_DETAILS = [LIBERTY_VERSION, { 'uri' => 'wlp-developers.jar', 'license' => 'spec/fixtures/license.html' }]
 
           LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
            .and_return(LIBERTY_OS_DETAILS)
@@ -554,7 +554,7 @@ module LibertyBuildpack::Container
             file.write('test file that should still exist after overlay')
           end
 
-          LIBERTY_OS_DETAILS = [LIBERTY_VERSION, 'wlp-developers.jar', 'spec/fixtures/license.html']
+          LIBERTY_OS_DETAILS = [LIBERTY_VERSION, { 'uri' => 'wlp-developers.jar', 'license' => 'spec/fixtures/license.html' }]
 
           LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item) { |&block| block.call(LIBERTY_VERSION) if block }
            .and_return(LIBERTY_OS_DETAILS)

--- a/spec/liberty_buildpack/jre/ibmjdk_spec.rb
+++ b/spec/liberty_buildpack/jre/ibmjdk_spec.rb
@@ -34,7 +34,7 @@ module LibertyBuildpack::Jre
       if find_item
         token_version = example.metadata[:service_release]
 
-        ibmjdk_config = [LibertyBuildpack::Util::TokenizedVersion.new(token_version), uri, 'spec/fixtures/license.html']
+        ibmjdk_config = [LibertyBuildpack::Util::TokenizedVersion.new(token_version), { 'uri' => uri, 'license' => 'spec/fixtures/license.html' }]
         LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item).and_return(ibmjdk_config)
       else
         LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item).and_raise(example.metadata[:raise_error_message])

--- a/spec/liberty_buildpack/repository/repository_index_spec.rb
+++ b/spec/liberty_buildpack/repository/repository_index_spec.rb
@@ -1,6 +1,6 @@
 # Encoding: utf-8
 # IBM WebSphere Application Server Liberty Buildpack
-# Copyright 2013-2014 the original author or authors.
+# Copyright 2013-2015 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,34 +15,129 @@
 # limitations under the License.
 
 require 'spec_helper'
-require 'liberty_buildpack/util/cache/download_cache'
+require 'application_helper'
+require 'logging_helper'
+require 'fileutils'
 require 'liberty_buildpack/repository/repository_index'
+require 'liberty_buildpack/repository/version_resolver'
+require 'liberty_buildpack/util/configuration_utils'
+require 'liberty_buildpack/util/cache/download_cache'
+require 'liberty_buildpack/util/tokenized_version'
 
-module LibertyBuildpack::Repository
+describe LibertyBuildpack::Repository::RepositoryIndex do
+  include_context 'application_helper'
+  include_context 'logging_helper'
 
-  describe RepositoryIndex do
+  let(:application_cache) { double('ApplicationCache') }
 
-    let(:application_cache) { double('ApplicationCache') }
+  before do
+    allow(LibertyBuildpack::Util::Cache::DownloadCache).to receive(:new).and_return(application_cache)
+    LibertyBuildpack::Repository::RepositoryIndex.class_variable_set(:@@platform, nil)
+    LibertyBuildpack::Repository::RepositoryIndex.class_variable_set(:@@architecture, nil)
+    LibertyBuildpack::Repository::RepositoryIndex.class_variable_set(:@@default_repository_root, nil)
+  end
 
-    it 'should load index with license' do
-      LibertyBuildpack::Util::Cache::DownloadCache.stub(:new).and_return(application_cache)
-      application_cache.stub(:get).with('test-uri/index.yml')
-      .and_yield(File.open('spec/fixtures/test-index.yml'))
-      VersionResolver.stub(:resolve).with('test-version', %w(resolved-version)).and_return('resolved-version')
+  it 'loads index' do
+    allow(application_cache).to receive(:get).with(%r{/test-uri/index\.yml})
+                                  .and_yield(Pathname.new('spec/fixtures/test-index.yml').open)
+    allow(LibertyBuildpack::Repository::VersionResolver).to receive(:resolve).with('test-version', %w(resolved-version))
+                                                           .and_return('resolved-version')
 
-      repository_index = RepositoryIndex.new('test-uri')
-      expect(repository_index.find_item('test-version')).to eq(%w(resolved-version resolved-uri resolved-license))
-    end
+    repository_index = described_class.new('{platform}/{architecture}/test-uri')
 
-    it 'should load index without license' do
-      LibertyBuildpack::Util::Cache::DownloadCache.stub(:new).and_return(application_cache)
-      application_cache.stub(:get).with('test-uri/index.yml')
-      .and_yield(File.open('spec/fixtures/test-index-orig.yml'))
-      VersionResolver.stub(:resolve).with('test-version', %w(resolved-version)).and_return('resolved-version')
+    result = repository_index.find_item('test-version')
+    expect(result.length).to eq(2)
+    expect(result[0]).to eq('resolved-version')
+    expect(result[1]['uri']).to eq('resolved-uri')
+    expect(result[1]['license']).to eq('resolved-license')
+  end
 
-      repository_index = RepositoryIndex.new('test-uri')
-      expect(repository_index.find_item('test-version')).to eq(['resolved-version', 'resolved-uri', nil])
-    end
+  it 'copes with trailing slash in repository URI' do
+    allow(application_cache).to receive(:get).with(%r{/test-uri/index\.yml})
+                                  .and_yield(Pathname.new('spec/fixtures/test-index.yml').open)
+    allow(LibertyBuildpack::Repository::VersionResolver).to receive(:resolve).with('test-version', %w(resolved-version))
+                                                           .and_return('resolved-version')
+
+    repository_index = described_class.new('{platform}/{architecture}/test-uri/')
+
+    result = repository_index.find_item('test-version')
+    expect(result.length).to eq(2)
+    expect(result[0]).to eq('resolved-version')
+    expect(result[1]['uri']).to eq('resolved-uri')
+    expect(result[1]['license']).to eq('resolved-license')
+  end
+
+  it 'substitutes the default repository root' do
+    allow(LibertyBuildpack::Util::ConfigurationUtils)
+      .to receive(:load).with('repository').and_return('default_repository_root' => 'http://default-repository-root/')
+    expect(application_cache).to receive(:get).with('http://default-repository-root/test-uri/index.yml')
+                                   .and_yield(Pathname.new('spec/fixtures/test-index.yml').open)
+
+    described_class.new('{default.repository.root}/test-uri')
+  end
+
+  it 'handles Centos' do
+    allow(Pathname).to receive(:new).and_call_original
+    redhat_release = double('redhat-release')
+    allow(Pathname).to receive(:new).with('/etc/redhat-release').and_return(redhat_release)
+
+    allow_any_instance_of(described_class).to receive(:`).with('uname -s').and_return('Linux')
+    allow_any_instance_of(described_class).to receive(:`).with('uname -m').and_return('x86_64')
+    allow_any_instance_of(described_class).to receive(:`).with('which lsb_release 2> /dev/null').and_return('')
+    allow(redhat_release).to receive(:exist?).and_return(true)
+    allow(redhat_release).to receive(:read).and_return('CentOS release 6.4 (Final)')
+    allow(application_cache).to receive(:get).with('centos6/x86_64/test-uri/index.yml')
+                                  .and_yield(Pathname.new('spec/fixtures/test-index.yml').open)
+
+    described_class.new('{platform}/{architecture}/test-uri')
+
+    expect(application_cache).to have_received(:get).with %r{centos6/x86_64/test-uri/index\.yml}
+  end
+
+  it 'handles Mac OS X' do
+    allow(Pathname).to receive(:new).and_call_original
+    non_redhat = double('non-redhat', exist?: false)
+    allow(Pathname).to receive(:new).with('/etc/redhat-release').and_return(non_redhat)
+
+    allow_any_instance_of(described_class).to receive(:`).with('uname -s').and_return('Darwin')
+    allow_any_instance_of(described_class).to receive(:`).with('uname -m').and_return('x86_64')
+    allow(application_cache).to receive(:get).with('mountainlion/x86_64/test-uri/index.yml')
+                                  .and_yield(Pathname.new('spec/fixtures/test-index.yml').open)
+
+    described_class.new('{platform}/{architecture}/test-uri')
+
+    expect(application_cache).to have_received(:get).with %r{mountainlion/x86_64/test-uri/index\.yml}
+  end
+
+  it 'handles Ubuntu' do
+    allow(Pathname).to receive(:new).and_call_original
+    non_redhat = double('non-redhat', exist?: false)
+    allow(Pathname).to receive(:new).with('/etc/redhat-release').and_return(non_redhat)
+
+    allow_any_instance_of(described_class).to receive(:`).with('uname -s').and_return('Linux')
+    allow_any_instance_of(described_class).to receive(:`).with('uname -m').and_return('x86_64')
+    allow_any_instance_of(described_class).to receive(:`).with('which lsb_release 2> /dev/null')
+                                                .and_return('/usr/bin/lsb_release')
+    allow_any_instance_of(described_class).to receive(:`).with('lsb_release -cs').and_return('precise')
+    allow(application_cache).to receive(:get).with('precise/x86_64/test-uri/index.yml')
+                                  .and_yield(Pathname.new('spec/fixtures/test-index.yml').open)
+
+    described_class.new('{platform}/{architecture}/test-uri')
+
+    expect(application_cache).to have_received(:get).with %r{precise/x86_64/test-uri/index\.yml}
+  end
+
+  it 'handles unknown OS' do
+    allow(Pathname).to receive(:new).and_call_original
+    non_redhat = double('non-redhat', exist?: false)
+    allow(Pathname).to receive(:new).with('/etc/redhat-release').and_return(non_redhat)
+
+    allow_any_instance_of(File).to receive(:exists?).with('/etc/redhat-release').and_return(false)
+    allow_any_instance_of(described_class).to receive(:`).with('uname -s').and_return('Linux')
+    allow_any_instance_of(described_class).to receive(:`).with('which lsb_release 2> /dev/null').and_return('')
+
+    expect { described_class.new('{platform}/{architecture}/test-uri') }
+      .to raise_error('Unable to determine platform')
   end
 
 end

--- a/spec/liberty_buildpack/repository/version_resolver_spec.rb
+++ b/spec/liberty_buildpack/repository/version_resolver_spec.rb
@@ -1,6 +1,6 @@
 # Encoding: utf-8
 # IBM WebSphere Application Server Liberty Buildpack
-# Copyright 2013 the original author or authors.
+# Copyright 2013-2015 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,60 +16,52 @@
 
 require 'spec_helper'
 require 'liberty_buildpack/repository/version_resolver'
+require 'liberty_buildpack/util/tokenized_version'
 
-module LibertyBuildpack::Repository
+describe LibertyBuildpack::Repository::VersionResolver do
 
-  describe VersionResolver do
+  let(:versions) { %w(1.6.0_26 1.6.0_27 1.6.1_14 1.7.0_19 1.7.0_21 1.8.0_M-7 1.8.0_05 2.0.0) }
 
-    VERSIONS = [
-      '1.6.0_26',
-      '1.6.0_27',
-      '1.6.1_14',
-      '1.7.0_19',
-      '1.7.0_21',
-      '1.8.0_M-7',
-      '1.8.0_05',
-      '2.0.0'
-    ]
+  it 'resolves the default version if no candidate is supplied' do
+    expect(described_class.resolve(nil, versions)).to eq(tokenized_version('2.0.0'))
+  end
 
-    it 'resolves the default version if no candidate is supplied' do
-      expect(VersionResolver.resolve(nil, VERSIONS).to_s).to eq('2.0.0')
-    end
+  it 'resolves a wildcard major version' do
+    expect(described_class.resolve(tokenized_version('+'), versions)).to eq(tokenized_version('2.0.0'))
+  end
 
-    it 'resolves a wildcard major version' do
-      expect(VersionResolver.resolve(LibertyBuildpack::Util::TokenizedVersion.new('+'), VERSIONS).to_s).to eq('2.0.0')
-    end
+  it 'resolves a wildcard minor version' do
+    expect(described_class.resolve(tokenized_version('1.+'), versions)).to eq(tokenized_version('1.8.0_05'))
+  end
 
-    it 'resolves a wildcard minor version' do
-      expect(VersionResolver.resolve(LibertyBuildpack::Util::TokenizedVersion.new('1.+'), VERSIONS).to_s).to eq('1.8.0_05')
-    end
+  it 'resolves a wildcard micro version' do
+    expect(described_class.resolve(tokenized_version('1.6.+'), versions)).to eq(tokenized_version('1.6.1_14'))
+  end
 
-    it 'resolves a wildcard micro version' do
-      expect(VersionResolver.resolve(LibertyBuildpack::Util::TokenizedVersion.new('1.6.+'), VERSIONS).to_s).to eq('1.6.1_14')
-    end
+  it 'resolves a wildcard qualifier' do
+    expect(described_class.resolve(tokenized_version('1.6.0_+'), versions)).to eq(tokenized_version('1.6.0_27'))
+    expect(described_class.resolve(tokenized_version('1.8.0_+'), versions)).to eq(tokenized_version('1.8.0_05'))
+  end
 
-    it 'resolves a wildcard qualifier' do
-      expect(VersionResolver.resolve(LibertyBuildpack::Util::TokenizedVersion.new('1.6.0_+'), VERSIONS).to_s).to eq('1.6.0_27')
-      expect(VersionResolver.resolve(LibertyBuildpack::Util::TokenizedVersion.new('1.8.0_+'), VERSIONS).to_s).to eq('1.8.0_05')
-    end
+  it 'resolves a non-wildcard version' do
+    expect(described_class.resolve(tokenized_version('1.6.0_26'), versions)).to eq(tokenized_version('1.6.0_26'))
+    expect(described_class.resolve(tokenized_version('2.0.0'), versions)).to eq(tokenized_version('2.0.0'))
+  end
 
-    it 'resolves a non-wildcard version' do
-      expect(VersionResolver.resolve(LibertyBuildpack::Util::TokenizedVersion.new('1.6.0_26'), VERSIONS).to_s).to eq('1.6.0_26')
-      expect(VersionResolver.resolve(LibertyBuildpack::Util::TokenizedVersion.new('2.0.0'), VERSIONS).to_s).to eq('2.0.0')
-    end
+  it 'resolves a non-digit qualifier' do
+    expect(described_class.resolve(tokenized_version('1.8.0_M-7'), versions)).to eq(tokenized_version('1.8.0_M-7'))
+  end
 
-    it 'resolves a non-digit qualifier' do
-      expect(VersionResolver.resolve(LibertyBuildpack::Util::TokenizedVersion.new('1.8.0_M-7'), VERSIONS).to_s).to eq('1.8.0_M-7')
-    end
+  it 'raises an exception if no version can be resolved' do
+    expect(described_class.resolve(tokenized_version('2.1.0'), versions)).to be_nil
+  end
 
-    it 'should raise an exception if no version can be resolved' do
-      expect { VersionResolver.resolve(LibertyBuildpack::Util::TokenizedVersion.new('2.1.0'), VERSIONS).to_s }.to raise_error
-    end
+  it 'raises an exception when a wildcard is specified in the [] collection' do
+    expect { described_class.resolve(tokenized_version('1.6.0_25'), %w(+)) }.to raise_error(/Invalid/)
+  end
 
-    it 'should raise an exception when a wildcard is specified in the [] collection' do
-      expect { VersionResolver.resolve(LibertyBuildpack::Util::TokenizedVersion.new('1.6.0_25'), ['+']) }.to raise_error(/Invalid/)
-    end
-
+  def tokenized_version(s)
+    LibertyBuildpack::Util::TokenizedVersion.new(s)
   end
 
 end


### PR DESCRIPTION
Synchronize the `lib/liberty_buildpack/repository` code from the Java buildpack with some minor changes. This provides ability to resolve repository_root with variables such as `'{default.repository.root}/openjdk/{platform}/{architecture}'`