### PR TITLE
Use Java EE 7 Web Profile features by default

### DIFF
--- a/config/liberty.yml
+++ b/config/liberty.yml
@@ -17,6 +17,7 @@
 ---
 repository_root: "https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/"
 version: 8.5.+
+type: webProfile7
 minify: false
 app_state: true
 liberty_repository_properties:
@@ -26,17 +27,21 @@ app_archive:
  # Scan archives that do not contain beans.xml for bean-definition annotations (cdi 1.2)
  implicit_cdi: false
  # Default features
- features: 
- - jsf-2.0
- - jsp-2.2
- - servlet-3.0
- - ejbLite-3.1
- - cdi-1.0
- - jpa-2.0
- - jdbc-4.0
+ features:
+ - beanValidation-1.1
+ - cdi-1.2
+ - ejbLite-3.2
+ - el-3.0
+ - jaxrs-2.0
+ - jdbc-4.1
  - jndi-1.0
+ - jpa-2.1
+ - jsf-2.2
+ - jsonp-1.0
+ - jsp-2.3
  - managedBeans-1.0
- - jaxrs-1.1
+ - servlet-3.1
+ - websocket-1.1
 
 # Map of optional Liberty component download name to feature names.
 # Used when liberty_repository_properties/useRepository is false.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,39 +1,5 @@
 Configuration
 =============
 
-Buildpack configuration can be overridden with an environment variable matching the [configuration file](../config) you wish to override minus the `.yml` extension and with a prefix of `JBP_CONFIG`. The value of the variable should be valid inline YAML. For example:
-
-1. Configure the buildpack to use [Liberty profile](container-liberty.md) beta:
-
-    ```bash
-    cf set-env myApplication JBP_CONFIG_LIBERTY 'version: 2015.+'
-    ```
-
-1. Configure the buildpack with a custom set of [Liberty profile](container-liberty.md) features (for WAR and EAR files only):
-
-    ```bash
-    cf set-env myApplication JBP_CONFIG_LIBERTY 'app_archive: {features: [jsp-2.2, websocket-1.1]}'
-    ```
-
-1. Configure the buildpack to use [OpenJDK](open-jdk.md) 8:
-
-   ```bash
-   cf set-env myApplication JBP_CONFIG_OPENJDK 'version: 1.8.+'
-   cf set-env myApplication JVM openjdk
-   ```
-
-1. Configure the buildpack to use [OpenJDK](open-jdk.md) 8 with larger Metaspace size:
-
-   ```bash
-   cf set-env myApplication JBP_CONFIG_OPENJDK '[version: 1.8.+, memory_sizes: { metaspace: 256m }]'
-   cf set-env myApplication JVM openjdk
-   ```
-
-1. Disable [Spring Auto Reconfiguration](framework-spring-auto-reconfiguration.md):
-
-   ```bash
-   cf set-env myApplication JBP_CONFIG_SPRINGAUTORECONFIGURATION 'enabled: false'
-   ```
-
-The environment variables can also be specified in the [manifest.yml](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) file. Checkout the sample [manifest.yml](./configuration/manifest.yml) file that sets Liberty features and configures IBM JRE version. 
+The buildpack configuration can be overridden with an environment variable matching the [configuration file](../config) you wish to override minus the `.yml` extension and with a prefix of `JBP_CONFIG`. The value of the variable should be valid inline YAML. See the [Liberty container](container-liberty.md#common-configuration-overrides), [OpenJDK JRE](open-jdk.md#common-configuration-overrides), and [Spring Auto Reconfiguration framework](framework-spring-auto-reconfiguration.md#common-configuration-overrides) for examples. Also, see the sample [manifest.yml](./configuration/manifest.yml) file that uses configuration overrides environment variables to set Liberty features and configure version of the IBM JRE.
 

--- a/docs/container-liberty.md
+++ b/docs/container-liberty.md
@@ -1,5 +1,5 @@
 # Liberty Container
-The Liberty Container runs Java EE 6 and 7 applications on [IBM's WebSphere Application Server Liberty Profile](http://www14.software.ibm.com/webapp/wsbroker/redirect?version=phil&product=was-nd-mp&topic=thread_twlp_devenv). It recognizes Web Archive (WAR) and Enterprise Archive (EAR) files as well applications deployed as a [Liberty server directory](http://www14.software.ibm.com/webapp/wsbroker/redirect?version=phil&product=was-nd-dist&topic=twlp_setup_new_server) or [packaged server](http://www14.software.ibm.com/webapp/wsbroker/redirect?version=phil&product=was-nd-mp&topic=twlp_setup_package_server).
+The Liberty container runs Java EE 6 and 7 applications on [IBM's WebSphere Application Server Liberty Profile](http://www14.software.ibm.com/webapp/wsbroker/redirect?version=phil&product=was-nd-mp&topic=thread_twlp_devenv). It recognizes Web Archive (WAR) and Enterprise Archive (EAR) files as well applications deployed as a [Liberty server directory](http://www14.software.ibm.com/webapp/wsbroker/redirect?version=phil&product=was-nd-dist&topic=twlp_setup_new_server) or [packaged server](http://www14.software.ibm.com/webapp/wsbroker/redirect?version=phil&product=was-nd-mp&topic=twlp_setup_package_server).
 
 <table border>
   <tr>
@@ -28,6 +28,7 @@ The Liberty container can be configured by modifying the [`config/liberty.yml`][
 | ---- | -----------
 |`repository_root`| The URL of the Liberty repository index ([details][repositories]).
 |`version`| The version of the Liberty profile. You can find the candidate versions [here][index.yml].
+| `type` | The archive type of Liberty runtime to download. One of `webProfile6`, `webProfile7`, `javaee7`, or `kernel`. The default value is `webProfile7`. 
 |`minify`| Boolean indicating whether the Liberty server should be [minified](#minify). The default value is `false`.
 | `liberty_repository_properties` | [Liberty repository configuration](#liberty-repository-configuration). 
 | `app_archive` | [Default configuration](#default-configuration) for WAR and EAR files. 
@@ -62,17 +63,45 @@ app_archive:
  implicit_cdi: false
  # Default features
  features: 
- - jsf-2.0
- - jsp-2.2
- - servlet-3.0
- - ejbLite-3.1
- - cdi-1.0
- - jpa-2.0
- - jdbc-4.0
+ - beanValidation-1.1
+ - cdi-1.2
+ - ejbLite-3.2
+ - el-3.0
+ - jaxrs-2.0
+ - jdbc-4.1
  - jndi-1.0
+ - jpa-2.1
+ - jsf-2.2
+ - jsonp-1.0
+ - jsp-2.3
  - managedBeans-1.0
- - jaxrs-1.1
+ - servlet-3.1
+ - websocket-1.1
 ```
+
+## Common Configuration Overrides
+
+The Liberty container [configuration can be overridden](configuration.md) with the `JBP_CONFIG_LIBERTY` environment variable. The value of the variable should be valid inline YAML. For example:
+
+1. Configure the Liberty container to enable a custom set of Liberty features (for WAR and EAR files only):
+
+    ```bash
+    $ cf set-env myApplication JBP_CONFIG_LIBERTY 'app_archive: {features: [jsp-2.3, websocket-1.1]}'
+    ```
+
+1. Configure the Liberty container to download and install Liberty profile runtime with all Java EE 7 features:
+
+    ```bash
+    $ cf set-env myApplication JBP_CONFIG_LIBERTY 'type: javaee7'
+    ```
+
+1. Configure the Liberty container to download and install Liberty profile beta:
+
+    ```bash
+    $ cf set-env myApplication JBP_CONFIG_LIBERTY 'version: 2015.+'
+    ```
+
+The environment variables can also be specified in the [manifest.yml](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) file.
 
 [liberty.yml]: ../config/liberty.yml
 [repositories]: util-repositories.md

--- a/docs/framework-spring-auto-reconfiguration.md
+++ b/docs/framework-spring-auto-reconfiguration.md
@@ -33,6 +33,18 @@ To configure the framework, you can modify the [`config/springautoreconfiguratio
 | `repository_root` | The URL of the Auto Reconfiguration repository index ([details][repositories]).
 | `version` | The version of Auto Reconfiguration to use. You can find the candidate versions [here][].
 
+## Common Configuration Overrides
+
+The Spring Auto Reconfiguration framework [configuration can be overridden](configuration.md) with the `JBP_CONFIG_SPRINGAUTORECONFIGURATION` environment variable. The value of the variable should be valid inline YAML. For example:
+
+1. Disable the framework:
+
+   ```bash
+   $ cf set-env myApplication JBP_CONFIG_SPRINGAUTORECONFIGURATION 'enabled: false'
+   ```
+
+The environment variables can also be specified in the [manifest.yml](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) file.
+
 [Configuration and Extension]: ../README.md#Configuration-and-Extension
 [`config/springautoreconfiguration.yml`]: ../config/springautoreconfiguration.yml
 [repositories]: util-repositories.md

--- a/docs/open-jdk.md
+++ b/docs/open-jdk.md
@@ -69,6 +69,24 @@ the range, the constrained size is excluded from the remaining memory, and no fu
 
 Termination is guaranteed since there is a finite number of memory types and in each iteration either none of the remaining memory sizes is constrained by the corresponding range and allocation terminates or at least one memory size is constrained by the corresponding range and is omitted from the next iteration.
 
+## Common Configuration Overrides
+
+The OpenJDK JRE [configuration can be overridden](configuration.md) with the `JBP_CONFIG_OPENJDK` environment variable. The value of the variable should be valid inline YAML. For example:
+
+1. Configure larger metaspace size:
+
+   ```bash
+   $ cf set-env myApplication JBP_CONFIG_OPENJDK 'memory_sizes: { metaspace: 256m }'
+   ```
+
+1. Use OpenJDK version 7:
+
+   ```bash
+   $ cf set-env myApplication JBP_CONFIG_OPENJDK 'version: 1.7.+'
+   ```
+
+The environment variables can also be specified in the [manifest.yml](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) file.
+
 [`config/openjdk.yml`]: ../config/openjdk.yml
 [centos6]: http://download.pivotal.io.s3.amazonaws.com/openjdk/centos6/x86_64/index.yml
 [lucid]: http://download.pivotal.io.s3.amazonaws.com/openjdk/lucid/x86_64/index.yml

--- a/docs/server-xml-options.md
+++ b/docs/server-xml-options.md
@@ -1,4 +1,4 @@
-Buildpack-enabled Options for Server.xml
+Buildpack-enabled Options for server.xml
 ========================================
 
 Liberty's server behavior is controlled through a file with the name `server.xml`.
@@ -8,37 +8,42 @@ If you are pushing a WAR, EAR or "exploded" (i.e. unzipped) file of either type,
 server.xml will be generated for you with the correct parameters for use
 with Cloud Foundry.  That server.xml will look something like this:
 
-```
+```xml
 <server>
-<server description="new server">
-
-    <!-- Enable features -->
     <featureManager>
-        <feature>jsf-2.0</feature>
-        <feature>jsp-2.2</feature>
-        <feature>servlet-3.0</feature>
-        <feature>ejbLite-3.1</feature>
-        <feature>cdi-1.0</feature>
-        <feature>jpa-2.0</feature>
-        <feature>jdbc-4.0</feature>
-        <feature>transaction-1.1</feature>
+        <feature>beanValidation-1.1</feature>
+        <feature>cdi-1.2</feature>
+        <feature>ejbLite-3.2</feature>
+        <feature>el-3.0</feature>
+        <feature>jaxrs-2.0</feature>
+        <feature>jdbc-4.1</feature>
         <feature>jndi-1.0</feature>
+        <feature>jpa-2.1</feature>
+        <feature>jsf-2.2</feature>
+        <feature>jsonp-1.0</feature>
+        <feature>jsp-2.3</feature>
         <feature>managedBeans-1.0</feature>
-        <feature>jaxrs-1.1</feature>
+        <feature>servlet-3.1</feature>
+        <feature>websocket-1.1</feature>
     </featureManager>
-
-    <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${port}"/>
+    <application name='myapp' location='myapp.war' type='war' context-root='/'/>
+    <cdi12 enableImplicitBeanArchives='false'/>
+    <httpEndpoint id='defaultHttpEndpoint' host='*' httpPort='${port}'/>
+    <webContainer trustHostHeaderPort='true' extractHostHeaderPort='true'/>
+    <include location='runtime-vars.xml'/>
+    <logging logDirectory='${application.log.dir}' consoleLogLevel='INFO'/>
+    <httpDispatcher enableWelcomePage='false'/>
+    <applicationMonitor dropinsEnabled='false' updateTrigger='mbean'/>
+    <config updateTrigger='mbean'/>
 </server>
+
 ```
 
-**NOTE**: This server.xml will also contain a reference to the application
-you pushed, with the type of the application (war/ear) and context root "/".  That is to say, if you pushed an app
-using the command `cf push foo`, and your domain is `mydomain.com`, your
-application will be accessible from `http://foo.mydomain.com/`.
+**NOTE**: The `application` element will be updated with the type of the application you deployed (war or ear) and the context root for your application. By default, the context root of `/` is used, unless otherwise set in the `WEB-INF/ibm-web-ext.xml` file embedded with your application. 
 
-Since you are not pushing a server.xml with your application, you are
-foregoing any control over the server's behavior, and the default behavior
-is assumed.
+If you deployed an application using the command `cf push foo`, and your domain is `mydomain.com`, and the application uses the default context root, the application will be accessible from `http://foo.mydomain.com/`. If the application uses a non-default context root, say `/bar`, the application will be accessible from `http://foo.mydomain.com/bar`.
+
+Since you are not pushing a server.xml with your application, you are foregoing most of control over the server's behavior, and the default behavior is assumed. However, you can adjust some things such as the feature list. See the [Liberty container](container-liberty.md#common-configuration-overrides) for details.
 
 ## Server Configurations (including a server.xml)
 

--- a/lib/liberty_buildpack/container/feature_manager.rb
+++ b/lib/liberty_buildpack/container/feature_manager.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'English'
 require 'liberty_buildpack'
 require 'liberty_buildpack/container'
 require 'liberty_buildpack/diagnostics/logger_factory'
@@ -73,11 +74,10 @@ module LibertyBuildpack::Container
 
           @logger.debug("script invocation string is #{script_string}")
           output = `#{script_string} 2>&1`
-          # if ($CHILD_STATUS.to_i == 0) doesn't seem to work, as $CHILD_STATUS is
-          # nil, so parse output for known message codes.
-          if output.include?(FEATURES_ALREADY_PRESENT_MSG_CODE)
+          exitcode = $CHILD_STATUS.exitstatus
+          if exitcode == FEATURES_ALREADY_PRESENT_EXIT_CODE
             @logger.debug("no extra features to install, output is #{output}")
-          elsif output.include?(FEATURES_INSTALLED_MSG_CODE)
+          elsif exitcode == FEATURES_INSTALLED_EXIT_CODE
             @logger.debug("installed required features, output is #{output}")
           else
             @logger.debug("could not install required features, output is #{output}")
@@ -89,8 +89,8 @@ module LibertyBuildpack::Container
 
     private
 
-      FEATURES_ALREADY_PRESENT_MSG_CODE = 'CWWKF1216I'.freeze
-      FEATURES_INSTALLED_MSG_CODE       = 'CWWKF1017I'.freeze
+      FEATURES_ALREADY_PRESENT_EXIT_CODE = 22
+      FEATURES_INSTALLED_EXIT_CODE       = 0
 
       # common code used by internal instance method use_liberty_repository? and
       # public class method enabled?

--- a/resources/download_buildpack_cache.rb
+++ b/resources/download_buildpack_cache.rb
@@ -20,6 +20,7 @@ class BuildpackCache
   VERSION = 'version'.freeze
   URI_KEY = 'uri'.freeze
   LICENSE_KEY = 'license'.freeze
+  TYPE_KEY = 'type'.freeze
 
   # Creates an instance with the specified logger and locale cache destination
   #
@@ -55,7 +56,7 @@ class BuildpackCache
       end
       candidate = LibertyBuildpack::Util::TokenizedVersion.new(config[VERSION])
       version = LibertyBuildpack::Repository::VersionResolver.resolve(candidate, index.keys)
-      file_uri = download_license(index[version.to_s])
+      file_uri = download_license(index[version.to_s], config[TYPE_KEY])
       file = File.join(@cache_dir, filename(file_uri))
       download(file_uri, file)
       # If file is a component_index.yml parse and download files it references as well
@@ -77,12 +78,12 @@ class BuildpackCache
     "#{uri}#{INDEX_PATH}"
   end
 
-  def download_license(file_uri)
+  def download_license(file_uri, type)
     if file_uri.is_a? Hash
       license_uri = file_uri[LICENSE_KEY]
       license_file = File.join(@cache_dir, filename(license_uri))
       download(license_uri, license_file)
-      file_uri = file_uri[URI_KEY]
+      file_uri = file_uri[type.nil? ? URI_KEY : type]
     end
     file_uri
   end

--- a/spec/fixtures/liberty_feature_repository/test_feature_manager_bad_script
+++ b/spec/fixtures/liberty_feature_repository/test_feature_manager_bad_script
@@ -20,3 +20,5 @@ echo 'jvm args is ('$JVM_ARGS')' >> $OUTPUT_FILE
 # pretend the features requested were already present so we avoid throwing an
 # exception from buildpack code (before the test code analyzes the command).
 echo "neither already installed nor install success message code"
+
+exit 1

--- a/spec/fixtures/liberty_feature_repository/test_feature_manager_good_script
+++ b/spec/fixtures/liberty_feature_repository/test_feature_manager_good_script
@@ -20,3 +20,5 @@ echo 'jvm args is ('$JVM_ARGS')' >> $OUTPUT_FILE
 # pretend the features requested were already present so we avoid throwing an
 # exception from buildpack code (before the test code analyzes the command).
 echo "CWWKF1216I"
+
+exit 22


### PR DESCRIPTION
* Download and install Liberty runtime with Java EE 7 Web Profile features by default (instead of Java EE 6 Web Profile features).
* Ability to specify an alternative runtime archive to be used by setting the `type` attribute in `config/liberty.yml` file. The following types are supported: `webProfile6`, `webProfile7`, `javaee7`, and `kernel`.
* Fix feature manager code to check exit codes instead of examining output since the output has changed a bit between Liberty versions.
* A bunch of documentation updates related to the new feature set and configuration overrides.
