### PR TITLE
Switch to installUtility

### DIFF
--- a/docs/container-liberty.md
+++ b/docs/container-liberty.md
@@ -46,11 +46,22 @@ The `minify` option can be overridden on a per-application basis by specifying a
 
 #### Liberty repository configuration
 
-By default, the Buildpack will download the Liberty features specified in the `server.xml` from [Liberty repository](https://developer.ibm.com/wasdev/downloads/). To disable this feature, set the `useRepository` option to `false`.
+By default, the buildpack will download the Liberty features specified in the `server.xml` from the [Liberty repository][]. To disable this feature, set the `useRepository` option to `false`.
 
 ```yaml
 liberty_repository_properties:
   useRepository: true
+```
+
+When the `useRepository` option to `true`, you can pass additional properties under the `liberty_repository_properties` element to customize the repository information. The additional properties that can be set are defined in the [`installUtility`](http://www14.software.ibm.com/webapp/wsbroker/redirect?version=phil&product=was-base-dist&topic=twlp_config_installutility) documentation. For example, the following specifies a custom feature repository and disables access to the [Liberty repository][]:
+
+```yaml
+liberty_repository_properties:
+  useRepository: true
+  useDefaultRepository: false
+  myRepo.url: http://dev.repo.ibm.com:9080/ma/v1
+  myRepo.user: myUser
+  myRepo.userPassword: myPassword
 ```
 
 #### Default configuration 
@@ -109,4 +120,5 @@ The environment variables can also be specified in the [manifest.yml](http://doc
 [`SPRING_PROFILES_ACTIVE`]: http://docs.spring.io/spring/docs/4.0.0.RELEASE/javadoc-api/org/springframework/core/env/AbstractEnvironment.html#ACTIVE_PROFILES_PROPERTY_NAME
 [version_syntax]: util-repositories.md#version-syntax-and-ordering
 [index.yml]: http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml
+[Liberty repository]: https://developer.ibm.com/wasdev/downloads/
 

--- a/lib/liberty_buildpack/container/feature_manager.rb
+++ b/lib/liberty_buildpack/container/feature_manager.rb
@@ -69,8 +69,8 @@ module LibertyBuildpack::Container
         if use_liberty_repository?
           features = get_features(server_xml)
           jvm_args = get_jvm_args
-          cmd = File.join(liberty_home, 'bin', 'featureManager')
-          script_string = "JAVA_HOME=\"#{@app_dir}/#{@java_home}\" JVM_ARGS=#{jvm_args} #{cmd} install --acceptLicense #{features} --when-file-exists=replace"
+          cmd = File.join(liberty_home, 'bin', 'installUtility')
+          script_string = "JAVA_HOME=\"#{@app_dir}/#{@java_home}\" JVM_ARGS=#{jvm_args} #{cmd} install --acceptLicense #{features}"
 
           @logger.debug("script invocation string is #{script_string}")
           output = `#{script_string} 2>&1`
@@ -164,7 +164,7 @@ module LibertyBuildpack::Container
         @logger.debug('entry')
         server_xml_doc = LibertyBuildpack::Util::XmlUtils.read_xml_file(server_xml)
         features = REXML::XPath.match(server_xml_doc, '/server/featureManager/feature/text()[not(contains(., ":"))]')
-        features = features.join(',')
+        features = features.join(' ')
         @logger.debug("exit (#{features})")
         features
       end
@@ -177,7 +177,7 @@ module LibertyBuildpack::Container
       def get_jvm_args
         @logger.debug('entry')
         if use_liberty_repository_with_properties_file?
-          jvm_args = "-Drepository.description.url=\"file://#{@repository_description_properties_file}\""
+          jvm_args = "-DWLP_REPOSITORIES_PROPS=#{@repository_description_properties_file}"
         else
           jvm_args = ''
         end

--- a/lib/liberty_buildpack/container/liberty.rb
+++ b/lib/liberty_buildpack/container/liberty.rb
@@ -506,13 +506,10 @@ module LibertyBuildpack::Container
     end
 
     def make_server_script_runnable
-      server_script = File.join liberty_home, 'bin', 'server'
-      File.chmod(0755, server_script)
-      # scripts that need to be executable for the feature manager to work
-      feature_manager_script = File.join liberty_home, 'bin', 'featureManager'
-      File.chmod(0755, feature_manager_script)
-      product_info = File.join liberty_home, 'bin', 'productInfo'
-      File.chmod(0755, product_info)
+      %w{server featureManager productInfo installUtility}.each do | name |
+        script = File.join(liberty_home, 'bin', name)
+        File.chmod(0755, script) if File.exists?(script)
+      end
     end
 
     def server_name

--- a/spec/liberty_buildpack/container/feature_manager_spec.rb
+++ b/spec/liberty_buildpack/container/feature_manager_spec.rb
@@ -37,7 +37,7 @@ module LibertyBuildpack::Container
       liberty_dir = File.join(app_dir, '.liberty')
       liberty_bin_dir = File.join(liberty_dir, 'bin')
       FileUtils.mkdir_p(liberty_bin_dir)
-      feature_manager_script_file = File.join(liberty_bin_dir, 'featureManager')
+      feature_manager_script_file = File.join(liberty_bin_dir, 'installUtility')
       FileUtils.copy(test_feature_manager_script_file, feature_manager_script_file)
       system "chmod +x #{feature_manager_script_file}"
       return app_dir, liberty_dir, liberty_bin_dir # rubocop:disable RedundantReturn
@@ -64,7 +64,7 @@ module LibertyBuildpack::Container
         call_feature_manager(app_dir, liberty_dir, configuration_file, server_xml_file)
 
         # check liberty's featureManager was not called.
-        feature_manager_command_file = File.join(liberty_bin_dir, 'featureManager.txt')
+        feature_manager_command_file = File.join(liberty_bin_dir, 'installUtility.txt')
         expect(File.exists?(feature_manager_command_file)).to eq(false)
       end
     end
@@ -81,7 +81,7 @@ module LibertyBuildpack::Container
         call_feature_manager(app_dir, liberty_dir, configuration_file, server_xml_file)
 
         # check liberty's featureManager was not called.
-        feature_manager_command_file = File.join(liberty_bin_dir, 'featureManager.txt')
+        feature_manager_command_file = File.join(liberty_bin_dir, 'installUtility.txt')
         expect(File.exists?(feature_manager_command_file)).to eq(false)
       end
     end
@@ -98,7 +98,7 @@ module LibertyBuildpack::Container
         call_feature_manager(app_dir, liberty_dir, configuration_file, server_xml_file)
 
         # check liberty's featureManager was not called.
-        feature_manager_command_file = File.join(liberty_bin_dir, 'featureManager.txt')
+        feature_manager_command_file = File.join(liberty_bin_dir, 'installUtility.txt')
         expect(File.exists?(feature_manager_command_file)).to eq(false)
       end
     end
@@ -115,7 +115,7 @@ module LibertyBuildpack::Container
         call_feature_manager(app_dir, liberty_dir, configuration_file, server_xml_file)
 
         # check liberty's featureManager was called, with expected parameters.
-        feature_manager_command_file = File.join(liberty_bin_dir, 'featureManager.txt')
+        feature_manager_command_file = File.join(liberty_bin_dir, 'installUtility.txt')
         expect(File.exists?(feature_manager_command_file)).to eq(true)
         feature_manager_command = File.read feature_manager_command_file
         expect(feature_manager_command).to match(/jsp-2.2/)
@@ -145,7 +145,7 @@ module LibertyBuildpack::Container
         call_feature_manager(app_dir, liberty_dir, configuration_file, server_xml_file)
 
         # check liberty's featureManager was called, with expected parameters.
-        feature_manager_command_file = File.join(liberty_bin_dir, 'featureManager.txt')
+        feature_manager_command_file = File.join(liberty_bin_dir, 'installUtility.txt')
         expect(File.exists?(feature_manager_command_file)).to eq(true)
         feature_manager_command = File.read feature_manager_command_file
         expect(feature_manager_command).to match(/jsp-2.2/)
@@ -154,7 +154,7 @@ module LibertyBuildpack::Container
         expect(feature_manager_command).not_to match(/myUserFeature/)
         # look for : jvm args is (-Drepository.description.url=file:///<something>/.repository.description.properties)
         # (enclosing quotes on path removed once set as environment variable).
-        expect(feature_manager_command).to match(%r{jvm args is \(-Drepository.description.url=file:///.*/\.repository.description.properties\)})
+        expect(feature_manager_command).to match(/jvm args is \(-DWLP_REPOSITORIES_PROPS=.*\.repository.description.properties\)/)
         # look for : java home is (<something>/my-java-home)
         expect(feature_manager_command).to match(/java home is \(.*\/my-java-home\)/)
 
@@ -208,7 +208,7 @@ module LibertyBuildpack::Container
           call_feature_manager(app_dir, liberty_dir, configuration_file, server_xml_file)
 
           # check liberty's featureManager was called, with expected parameters.
-          feature_manager_command_file = File.join(liberty_bin_dir, 'featureManager.txt')
+          feature_manager_command_file = File.join(liberty_bin_dir, 'installUtility.txt')
           expect(File.exists?(feature_manager_command_file)).to eq(true)
           feature_manager_command = File.read feature_manager_command_file
           expect(feature_manager_command).to match(/jvm args is \(\)/)


### PR DESCRIPTION
* Switch to `installUtility` instead of `featureManager` to ensure overriding repository configuration is working as expected.
* Update documentation with information on how to override repository information.
