### PR TITLE
Check license id if license uri is provided in index.yml

### DIFF
--- a/lib/liberty_buildpack/jre/ibmjdk.rb
+++ b/lib/liberty_buildpack/jre/ibmjdk.rb
@@ -147,10 +147,10 @@ module LibertyBuildpack::Jre
 
     def self.find_ibmjdk(configuration)
       version, entry = LibertyBuildpack::Repository::ConfiguredItem.find_item(configuration)
-      if entry.include?('uri') && entry.include?('license')
+      if entry.is_a?(Hash)
         return version, entry['uri'], entry['license']
       else
-        return version, entry
+        return version, entry, nil
       end
     rescue => e
       raise RuntimeError, "IBM JRE error: #{e.message}", e.backtrace

--- a/lib/liberty_buildpack/util/license_management.rb
+++ b/lib/liberty_buildpack/util/license_management.rb
@@ -26,7 +26,7 @@ module LibertyBuildpack::Util
   # @param [String] license_id the license id provided by the user
   # @return [boolean] return true if the license id's match, false otherwise
   def self.check_license(license_uri, license_id)
-    raise 'The license URL has returned nil' if license_uri.nil?
+    return true if license_uri.nil?
 
     # The below regex ignores white space and grabs anything between the first occurrence of "D/N:" and "<".
     LibertyBuildpack::Util::Cache::ApplicationCache.new.get(license_uri) do |file|

--- a/spec/liberty_buildpack/jre/ibmjdk_spec.rb
+++ b/spec/liberty_buildpack/jre/ibmjdk_spec.rb
@@ -118,8 +118,22 @@ module LibertyBuildpack::Jre
           expect { compiled }.to output(/Avoid Trouble/).to_stdout
         end
 
+        it 'should fail when the license id is not provided', app_dir: '', license_ids: {} do
+          expect { compiled }.to raise_error
+        end
+
         it 'should fail when the license ids do not match', app_dir: '', license_ids: { 'IBM_JVM_LICENSE' => 'Incorrect' } do
           expect { compiled }.to raise_error
+        end
+
+        it 'should not fail when the license url is not provided', app_dir: '', license_ids: {}, cache_fixture: 'stub-ibm-java.tar.gz' do
+          ibmjdk_config = [LibertyBuildpack::Util::TokenizedVersion.new(service_release), { 'uri' => uri }]
+          LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item).and_return(ibmjdk_config)
+
+          compiled
+
+          java = File.join(app_dir, '.java', 'jre', 'bin', 'java')
+          expect(File.exists?(java)).to eq(true)
         end
 
         it 'places the killjava script (with appropriately substituted content) in the diagnostics directory', cache_fixture: 'stub-ibm-java.bin' do


### PR DESCRIPTION
* Check license ids only if the license uri is provided in `index.yml` file.
