### PR TITLE
Include buildpack version in detect script output

### DIFF
--- a/lib/liberty_buildpack/buildpack.rb
+++ b/lib/liberty_buildpack/buildpack.rb
@@ -63,7 +63,11 @@ module LibertyBuildpack
       framework_detections = Buildpack.component_detections @frameworks
       container_detections = Buildpack.component_detections @containers
       raise "Application can not be run by more than one container: #{container_detections.join(', ')}" if container_detections.size > 1
-      tags = container_detections.empty? ? [] : container_detections.concat([@jre_version]).concat(framework_detections).flatten.compact
+      buildpack_version = @buildpack_version.version_string
+      tags = container_detections.empty? ? [] : container_detections
+      tags.concat([buildpack_version, @jre_version]) unless tags.empty?
+      tags.concat(framework_detections) unless tags.empty?
+      tags = tags.flatten.compact
       tags
     end
 

--- a/lib/liberty_buildpack/buildpack_version.rb
+++ b/lib/liberty_buildpack/buildpack_version.rb
@@ -95,6 +95,20 @@ module LibertyBuildpack
       s.join(human_readable ? ' ' : '-')
     end
 
+    # Creates a clean string representation of the buildpack version if the version exists or an empty string if not.
+    # The string representation looks like the following:
+    # +[buildpack-<VERSION>]+.  Examples:
+    #
+    # +buildpack-2.1.2+ (custom version number)
+    # +buildpack-abcdefg (default version number from git commit)
+    # nil (default version number, not part of a git repository)
+    #
+    # @return [String] a clean +String+ representation of the version for use in detect script output
+    def version_string
+      s = 'buildpack-'.concat(@version) if @version
+      s
+    end
+
     private
 
     GIT_DIR = (Pathname.new(__FILE__).dirname + '../../.git').freeze


### PR DESCRIPTION
Buildpack version is included in the detect script output if version is set in config or environment variable, or if the buildpack is in a git repository.