### PR TITLE
Simplify DynaTrace agent jar file name

### DIFF
--- a/config/dynatraceagent.yml
+++ b/config/dynatraceagent.yml
@@ -15,5 +15,5 @@
 
 # Service configuration
 ---
-version: 6.3.0_+
+version: 6.+
 repository_root: ""


### PR DESCRIPTION
Removed the requirement for the filename of the DynaTrace agent listed in index.yml to match the version number which specifies that url.  Changed the default version that the buildpack looks for to 6.+ from 6.3.0_+.