### PR TITLE
Use Util.download_zip when downloading zip or jar archives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
     - rvm: "1.9.3-p545"
       env: COMMAND=rake
-    - rvm: "2.2.2"
+    - rvm: "2.2.4"
       env: COMMAND=rspec
 install: bundle install --deployment --without debug
 script: bundle exec $COMMAND

--- a/lib/liberty_buildpack/framework/dynamic_pulse_agent.rb
+++ b/lib/liberty_buildpack/framework/dynamic_pulse_agent.rb
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 require 'liberty_buildpack/diagnostics/common'
 require 'liberty_buildpack/diagnostics/logger_factory'
 require 'liberty_buildpack/framework'
@@ -93,13 +94,9 @@ module LibertyBuildpack::Framework
     # Downloads ZIP file from specified url
     def download_and_unzip(base_url, system_id, filename, save_to_dir)
       download_url = File.join(base_url, system_id, filename)
-      begin
-        LibertyBuildpack::Util.download('3.+', download_url, 'DynamicPULSE Agent', filename, save_to_dir)
-      rescue
-        @logger.error("[DynamicPULSE] Can't download #{filename} from #{download_url}. Please check dynamicpulse-remote.xml.")
-        raise
-      end
-      LibertyBuildpack::Container::ContainerUtils.unzip(File.join(save_to_dir, filename), save_to_dir)
+      LibertyBuildpack::Util.download_zip('3.+', download_url, 'DynamicPULSE Agent', save_to_dir)
+    rescue => e
+      raise "[DynamicPULSE] Can't download #{filename} from #{download_url}. Please check dynamicpulse-remote.xml. #{e.message}"
     end
 
   end

--- a/lib/liberty_buildpack/framework/dynatrace_agent.rb
+++ b/lib/liberty_buildpack/framework/dynatrace_agent.rb
@@ -77,10 +77,8 @@ module LibertyBuildpack::Framework
       FileUtils.mkdir_p(dt_home)
 
       @logger.debug("Dynatrace home directory: #{dt_home}")
-      full_jar_path = File.join(dt_home, DT_JAR)
 
-      download_agent(@version, @uri, DT_JAR, dt_home)
-      expand full_jar_path
+      download_and_install_agent(dt_home)
     end
 
     #-----------------------------------------------------------------------------------------
@@ -104,9 +102,6 @@ module LibertyBuildpack::Framework
 
     # Name of the default dynatrace profile
     DT_DEFAULT_PROFILE_NAME = 'Monitoring'.freeze
-
-    # Name of the dynatrace jar file
-    DT_JAR = 'dynatrace-agent-unix.jar'.freeze
 
     # VCAP_SERVICES keys
     CREDENTIALS_KEY = 'credentials'.freeze
@@ -138,10 +133,10 @@ module LibertyBuildpack::Framework
     #------------------------------------------------------------------------------------------
     # Download the agent library from the repository as specified in the dynatrace configuration.
     #------------------------------------------------------------------------------------------
-    def download_agent(version_desc, uri_source, target_jar_name, target_dir)
-      LibertyBuildpack::Util.download(version_desc, uri_source, target_jar_name, target_jar_name, target_dir)
+    def download_and_install_agent(dt_home)
+      LibertyBuildpack::Util.download_zip(@version, @uri, 'Dynatrace Agent', dt_home)
     rescue => e
-      raise "Unable to download the DynaTrace Agent jar. Ensure that the agent jar at #{uri_source} is available and accessible. #{e.message}"
+      raise "Unable to download the Dynatrace Agent jar. Ensure that the agent jar at #{@uri} is available and accessible. #{e.message}"
     end
 
     #------------------------------------------------------------------------------------------
@@ -152,12 +147,6 @@ module LibertyBuildpack::Framework
     #------------------------------------------------------------------------------------------
     def dt_service_exist?
       @services.one_service?(DT_SERVICE_NAME, SERVER_KEY)
-    end
-
-    def expand(file)
-      Dir.mktmpdir do |root|
-        `unzip -qq #{file} -d ./app/#{DT_HOME_DIR}/ 2>&1`
-      end
     end
 
     #------------------------------------------------------------------------------------------

--- a/lib/liberty_buildpack/framework/jrebel_agent.rb
+++ b/lib/liberty_buildpack/framework/jrebel_agent.rb
@@ -18,9 +18,7 @@ require 'liberty_buildpack/diagnostics/logger_factory'
 require 'liberty_buildpack/framework'
 require 'liberty_buildpack/repository/configured_item'
 require 'liberty_buildpack/util/download'
-require 'liberty_buildpack/util/cache/application_cache'
 require 'liberty_buildpack/container/common_paths'
-require 'liberty_buildpack/container/container_utils'
 
 module LibertyBuildpack::Framework
 
@@ -122,21 +120,9 @@ module LibertyBuildpack::Framework
     # Download the JRebel zip from the repository as specified in the JRebel configuration.
     #------------------------------------------------------------------------------------------
     def download_and_install_agent(jr_home)
-      download_start_time = Time.now
-      print "-----> Downloading JRebel Agent #{@version} from #{@uri} "
-      LibertyBuildpack::Util::Cache::ApplicationCache.new.get(@uri) do |file|
-        puts "(#{(Time.now - download_start_time).duration})"
-        install_agent(file, jr_home)
-      end
+      LibertyBuildpack::Util.download_zip(@version, @uri, 'JRebel Agent', jr_home)
     rescue => e
       raise "Unable to download the JRebel zip. Ensure that the zip at #{@uri} is available and accessible. #{e.message}"
-    end
-
-    def install_agent(file, jr_home)
-      print '         Installing archive ... '
-      install_start_time = Time.now
-      LibertyBuildpack::Container::ContainerUtils.unzip(file, jr_home)
-      puts "(#{(Time.now - install_start_time).duration})\n"
     end
 
     def openjdk?

--- a/lib/liberty_buildpack/framework/new_relic_agent.rb
+++ b/lib/liberty_buildpack/framework/new_relic_agent.rb
@@ -78,7 +78,7 @@ module LibertyBuildpack::Framework
 
       # place new relic resources in newrelic's home dir
       copy_agent_config(nr_home)
-      download_agent(@version, @uri, NR_JAR, nr_home)
+      download_agent(@version, @uri, jar_name, nr_home)
     end
 
     #-----------------------------------------------------------------------------------------
@@ -88,7 +88,7 @@ module LibertyBuildpack::Framework
       # new relic paths within the droplet
       app_dir = @common_paths.relative_location
       nr_home_dir = File.join(app_dir, NR_HOME_DIR)
-      nr_agent = File.join(nr_home_dir, NR_JAR)
+      nr_agent = File.join(nr_home_dir, jar_name)
       nr_logs_dir = @common_paths.log_directory
 
       # create the new relic agent command as java_opts
@@ -100,9 +100,6 @@ module LibertyBuildpack::Framework
     end
 
     private
-
-    # Name of the new relic jar file
-    NR_JAR = 'new-relic.jar'.freeze
 
     # Name of the new relic service
     NR_SERVICE_NAME = 'newrelic'.freeze
@@ -116,6 +113,10 @@ module LibertyBuildpack::Framework
 
     # new relic's directory of artifacts in the droplet
     NR_HOME_DIR = '.new_relic_agent'.freeze
+
+    def jar_name
+      "new-relic-#{@version}.jar"
+    end
 
     #-----------------------------------------------------------------------------------------
     # Determines if the New Relic service is included in VCAP_SERVICES based on whether the
@@ -166,7 +167,6 @@ module LibertyBuildpack::Framework
       begin
         @version, @uri = LibertyBuildpack::Repository::ConfiguredItem.find_item(@configuration)
       rescue => e
-        @logger.debug("Contents of the New Relic Agent configuration #{@configuration}")
         @logger.error("Unable to process the configuration for the New Relic Agent framework. #{e.message}")
       end
 
@@ -187,7 +187,7 @@ module LibertyBuildpack::Framework
     # Download the agent library from the repository as specified in the new relic configuration.
     #------------------------------------------------------------------------------------------
     def download_agent(version_desc, uri_source, target_jar_name, target_dir)
-      LibertyBuildpack::Util.download(version_desc, uri_source, target_jar_name, target_jar_name, target_dir)
+      LibertyBuildpack::Util.download(version_desc, uri_source, 'New Relic Agent', target_jar_name, target_dir)
     rescue => e
       raise "Unable to download the New Relic Agent jar. Ensure that the agent jar at #{uri_source} is available and accessible. #{e.message}"
     end

--- a/lib/liberty_buildpack/util/download.rb
+++ b/lib/liberty_buildpack/util/download.rb
@@ -18,6 +18,7 @@ require 'fileutils'
 require 'liberty_buildpack/util'
 require 'liberty_buildpack/util/cache/application_cache'
 require 'liberty_buildpack/util/format_duration'
+require 'liberty_buildpack/container/container_utils'
 
 module LibertyBuildpack::Util
 
@@ -29,15 +30,30 @@ module LibertyBuildpack::Util
   # @param [String] jar_name the filename of the item
   # @param [String] target_directory the path of the directory into which to download the item
   def self.download(version, uri, description, jar_name, target_directory)
-
     download_start_time = Time.now
     print "-----> Downloading #{description} #{version} from #{uri} "
-
     LibertyBuildpack::Util::Cache::ApplicationCache.new.get(uri) do |file| # TODO: Use global cache #50175265
       FileUtils.cp(file.path, File.join(target_directory, jar_name))
       puts "(#{(Time.now - download_start_time).duration})"
     end
+  end
 
+  # Downloads and expands a zip file.
+  #
+  # @param [LibertyBuildpack::Util::TokenizedVersion] version the version of the item
+  # @param [String] uri the URI of the item
+  # @param [String] description a description of the item
+  # @param [String] target_directory the path of the directory into which to download the item
+  def self.download_zip(version, uri, description, target_directory)
+    download_start_time = Time.now
+    print "-----> Downloading #{description} #{version} from #{uri} "
+    LibertyBuildpack::Util::Cache::ApplicationCache.new.get(uri) do |file|
+      puts "(#{(Time.now - download_start_time).duration})"
+      print '         Expanding archive ... '
+      install_start_time = Time.now
+      LibertyBuildpack::Container::ContainerUtils.unzip(file, target_directory)
+      puts "(#{(Time.now - install_start_time).duration})\n"
+    end
   end
 
 end

--- a/spec/liberty_buildpack/framework/dynamic_pulse_agent_spec.rb
+++ b/spec/liberty_buildpack/framework/dynamic_pulse_agent_spec.rb
@@ -101,12 +101,14 @@ module LibertyBuildpack::Framework
       it 'should download the agent with a matching centerUrl and systemId' do
         FileUtils.cp(File.join(remote_dir, 'dynamicpulse-remote.xml'), File.join(webinf_dir, 'dynamicpulse-remote.xml'))
         expect { compiled }.to output(%r{Downloading DynamicPULSE Agent 3.+ from http://downloadsite/dynamicpulse/SampleWebApp/dynamicpulse-agent.zip}).to_stdout
-        expect(File.exists?(File.join(app_dir, '.dynamic_pulse_agent', 'dynamicpulse-agent.zip'))).to eq(true)
+        # zip file should not be there - just contents of it
+        expect(File.exists?(File.join(app_dir, '.dynamic_pulse_agent', 'dynamicpulse-agent.zip'))).to eq(false)
       end
 
       it 'should raise an error if the illegal centerUrl is in the dynamicpulse-remote.xml' do
         FileUtils.cp(File.join(remote_dir, 'dynamicpulse-remote_illegalCenterUrl.xml'), File.join(webinf_dir, 'dynamicpulse-remote.xml'))
-        allow(LibertyBuildpack::Util).to receive(:download).and_raise('underlying download error')
+        allow(LibertyBuildpack::Util).to receive(:download_zip).and_raise('underlying download error')
+        expect { compiled }.to raise_error(/Can't download dynamicpulse-agent.zip from..+underlying download error/)
       end
 
       it 'should raise an error if the centerUrl is not in the dynamicpulse-remote.xml' do

--- a/spec/liberty_buildpack/framework/dynatrace_agent_spec.rb
+++ b/spec/liberty_buildpack/framework/dynatrace_agent_spec.rb
@@ -205,14 +205,16 @@ module LibertyBuildpack::Framework
 
       describe 'download agent jar based on index.yml information' do
         it 'should download the agent with a matching key and jar version' do
-          expect { compiled }.to output(%r{Downloading #{jar_name} #{version} from https://downloadsite/dynatrace/dynatrace-agent-unix.jar}).to_stdout
-          expect(File.exists?(File.join(app_dir, dynatrace_home, jar_name))).to eq(true)
+          expect { compiled }.to output(%r{Downloading Dynatrace Agent #{version} from https://downloadsite/dynatrace/dynatrace-agent-unix.jar}).to_stdout
+          # jar file should not be there - just contents of it
+          expect(File.exists?(File.join(app_dir, dynatrace_home, jar_name))).to eq(false)
+          expect(File.exists?(File.join(app_dir, dynatrace_home, 'agent', 'linux-x86-64', 'agent', 'lib64', 'libdtagent.so'))).to eq(true)
         end
 
         it 'should raise an error with original exception if the jar could not be downloaded',
            index_version: '6.2.0_1238', index_uri: 'https://downloadsite/dynatrace/dynatrace-agent-unix.jar' do
-          allow(LibertyBuildpack::Util).to receive(:download).and_raise('underlying download error')
-          expect { compiled }.to raise_error(/Unable to download the DynaTrace Agent jar..+underlying download error/)
+          allow(LibertyBuildpack::Util).to receive(:download_zip).and_raise('underlying download error')
+          expect { compiled }.to raise_error(/Unable to download the Dynatrace Agent jar..+underlying download error/)
         end
       end
     end # end compile

--- a/spec/liberty_buildpack/framework/jrebel_agent_spec.rb
+++ b/spec/liberty_buildpack/framework/jrebel_agent_spec.rb
@@ -164,7 +164,7 @@ module LibertyBuildpack::Framework
 
         it 'should raise an error with original exception if the jar could not be downloaded',
            index_version: '6.0.3', index_uri: 'https://downloadsite/jrebel/jrebel-6.0.3-nosetup.zip' do
-          allow(LibertyBuildpack::Util::Cache::ApplicationCache).to receive(:new).and_raise('underlying download error')
+          allow(LibertyBuildpack::Util).to receive(:download_zip).and_raise('underlying download error')
           expect { compiled }.to raise_error(/Unable to download the JRebel zip\. Ensure that the zip at..+underlying download error/)
         end
       end

--- a/spec/liberty_buildpack/framework/new_relic_agent_spec.rb
+++ b/spec/liberty_buildpack/framework/new_relic_agent_spec.rb
@@ -29,7 +29,7 @@ module LibertyBuildpack::Framework
     let(:application_cache) { double('ApplicationCache') }
     let(:version) { '3.12.0' }
     let(:versionid) { "new-relic-#{version}" }
-    let(:jar_name) { 'new-relic.jar' }
+    let(:jar_name) { "new-relic-#{version}.jar" }
 
     before do | example |
       # an index.yml entry returned from the index.yml of the new relic repository
@@ -207,7 +207,7 @@ module LibertyBuildpack::Framework
 
       describe 'download agent jar based on index.yml information' do
         it 'should download the agent with a matching key and jar version' do
-          expect { compiled }.to output(%r{Downloading #{jar_name} #{version} from https://downloadsite/new-relic/new-relic-#{version}.jar}).to_stdout
+          expect { compiled }.to output(%r{Downloading New Relic Agent #{version} from https://downloadsite/new-relic/new-relic-#{version}.jar}).to_stdout
           expect(File.exists?(File.join(app_dir, newrelic_home, jar_name))).to eq(true)
         end
 


### PR DESCRIPTION
Use `Util.download_zip` when downloading zip or jar archives. More consistency and less code duplication.
