### PR TITLE
Add default repository for DynaTrace agent framework

### DIFF
--- a/config/dynatraceagent.yml
+++ b/config/dynatraceagent.yml
@@ -16,4 +16,4 @@
 # Service configuration
 ---
 version: 6.+
-repository_root: ""
+repository_root: "http://downloads.dynatracesaas.com/cloudfoundry/buildpack/java/"


### PR DESCRIPTION
Sets the default repository_root in DynaTrace agent framework configuration yml file to the DynaTrace hosted index.yml file.