### PR TITLE
Initialize logger for package command

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -89,6 +89,8 @@ task :package, [:zipfile, :hosts, :version] do |t, args|
       file.puts "hash: ''"
     end unless args.version.nil?
 
+    ENV['JBP_LOG_LEVEL'] = 'DEBUG' if ENV['JBP_LOG_LEVEL'].nil?
+
     bc = BuildpackCache.new(File.join(dest, 'admin_cache'))
     # Collect all remote content using all config files
     configs = bc.collect_configs nil, cache_hosts 

--- a/lib/liberty_buildpack/util.rb
+++ b/lib/liberty_buildpack/util.rb
@@ -21,32 +21,6 @@ require 'json'
 # A module encapsulating all of the utility code for the Java buildpack
 module LibertyBuildpack::Util
 
-  # Get env variables for a service you are filtering from the hash of VCAP_SERVICES
-  #
-  # @return [String] returns the env variables for the service
-  def find_service(vcap_services, filter)
-    return nil unless vcap_services
-
-    service_types = vcap_services.keys.select { |key| key =~ filter }
-    return nil if service_types.length > 1
-
-    service = nil
-    if service_types.length == 1
-      service_instances = vcap_services[service_types[0]]
-      return nil if service_instances.length != 1
-      service = service_instances[0]
-    else # user-provided service
-      user_services = vcap_services['user-provided']
-      if user_services
-        filtered_user_services = user_services.select { |v| v['name'] =~ filter }
-        return nil if filtered_user_services.length != 1
-        service = filtered_user_services[0]
-      end
-    end
-
-    service
-  end
-
   # Get services as either hash or string and return as the same object but
   # with credentials info masked out as PRIVATE DATA HIDDEN string
   #


### PR DESCRIPTION
1) Fixes `uninitialized class variable @@logger in LibertyBuildpack::Diagnostics::LoggerFactory"` error that can be generated sometimes.
2) Removed unused function from the `util.rb` class.
