### PR TITLE
Reset class variable before & after tests

### DIFF
--- a/spec/liberty_buildpack/repository/repository_index_spec.rb
+++ b/spec/liberty_buildpack/repository/repository_index_spec.rb
@@ -30,11 +30,19 @@ describe LibertyBuildpack::Repository::RepositoryIndex do
 
   let(:application_cache) { double('ApplicationCache') }
 
-  before do
-    allow(LibertyBuildpack::Util::Cache::DownloadCache).to receive(:new).and_return(application_cache)
+  def reset_variables
     LibertyBuildpack::Repository::RepositoryIndex.class_variable_set(:@@platform, nil)
     LibertyBuildpack::Repository::RepositoryIndex.class_variable_set(:@@architecture, nil)
     LibertyBuildpack::Repository::RepositoryIndex.class_variable_set(:@@default_repository_root, nil)
+  end
+
+  before do
+    allow(LibertyBuildpack::Util::Cache::DownloadCache).to receive(:new).and_return(application_cache)
+    reset_variables
+  end
+
+  after do
+    reset_variables
   end
 
   it 'loads index' do


### PR DESCRIPTION
This fix resolves the following test failure (which doesn't occur that often):

```ruby
  1) LibertyBuildpack::Services::Utils get_urls_for_client_jars via client_jar_url with variable
     Failure/Error: expect(result).to include(expected)
       expected ["http://default-repository-root/myPath"] to include "https://download.run.pivotal.io/myPath"
     # ./spec/liberty_buildpack/services/utils_spec.rb:583:in `block (3 levels) in <module:Services>'
```
