### PR TITLE
Return nil instead of throwing exception if the type is incorrect

### DIFF
--- a/lib/liberty_buildpack/jre/memory/memory_size.rb
+++ b/lib/liberty_buildpack/jre/memory/memory_size.rb
@@ -80,8 +80,7 @@ module LibertyBuildpack
       def <=>(other)
         if other == 0
           @bytes <=> 0
-        else
-          fail "Cannot compare a MemorySize to an instance of #{other.class}" unless other.is_a? MemorySize
+        elsif other.is_a? MemorySize
           @bytes <=> other.bytes
         end
       end

--- a/spec/liberty_buildpack/jre/memory/memory_size_spec.rb
+++ b/spec/liberty_buildpack/jre/memory/memory_size_spec.rb
@@ -75,7 +75,7 @@ describe LibertyBuildpack::Jre::MemorySize do
   end
 
   it 'should fail when a memory size is compared to a non-zero numeric' do
-    expect { described_class.new('1B') < 2 }.to raise_error(/Cannot compare/)
+    expect { described_class.new('1B') < 2 }.to raise_error(ArgumentError)
   end
 
   it 'should multiply values correctly' do


### PR DESCRIPTION
Gets rid off the following warnings:

```
/tmp/buildpack/lib/liberty_buildpack/jre/memory/memory_range.rb:84: warning: Comparable#== will no more rescue exceptions of #<=> in the next release.
/tmp/buildpack/lib/liberty_buildpack/jre/memory/memory_range.rb:84: warning: Return nil in #<=> if the comparison is inappropriate or avoid such comparison
```