### PR TITLE
Limit MariaDB JDBC driver to 1.4.+ versions

### DIFF
--- a/lib/liberty_buildpack/services/config/mysql.yml
+++ b/lib/liberty_buildpack/services/config/mysql.yml
@@ -31,5 +31,5 @@ client_jars : 'mariadb-java-client*.jar|mysql-connector-java*.jar'
 service_filter : 'mysql|cleardb'
 
 driver:
-  version: 1.+
+  version: 1.4.+
   repository_root: "https://download.run.pivotal.io/mariadb-jdbc"


### PR DESCRIPTION
Temporarily switch to use `1.4.+`  versions of the MariaDB JDBC driver as the latest one seems to be generating the following exception:
```
java.sql.SQLNonTransientException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '' at line 1
Query is : SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED DSRA0010E: SQL State = 42000, Error Code = 1,064
```