### PR TITLE
Add JVM options for IBM JDK to enable all TLS protocols

### DIFF
--- a/lib/liberty_buildpack/repository/configured_item.rb
+++ b/lib/liberty_buildpack/repository/configured_item.rb
@@ -47,7 +47,11 @@ module LibertyBuildpack
           index = index(repository_root)
           index.find_item version
         rescue => e
-          raise RuntimeError, "#{component_name} error: #{e.message}", e.backtrace unless component_name.nil?
+          if component_name.nil?
+            raise e
+          else
+            raise RuntimeError, "#{component_name} error: #{e.message}", e.backtrace
+          end
         end
 
         private

--- a/spec/liberty_buildpack/jre/ibmjdk_spec.rb
+++ b/spec/liberty_buildpack/jre/ibmjdk_spec.rb
@@ -153,7 +153,11 @@ module LibertyBuildpack::Jre
 
         # context is provided by component_helper, its default values are provided by 'describe' metadata, and
         # customized through test's metadata
-        subject(:released) { IBMJdk.new(context).release }
+        subject(:released) do
+          component = IBMJdk.new(context)
+          component.detect
+          component.release
+        end
 
         it 'should add default dump options that output data to the common dumps directory, if enabled' do
           expect(released).to include('-Xdump:none',
@@ -203,6 +207,30 @@ module LibertyBuildpack::Jre
       it_behaves_like 'IBMJDK v7', '1.7.1'
     end
 
+    describe 'TLS options',
+             java_home: '',
+             java_opts: [],
+             license_ids: { 'IBM_JVM_LICENSE' => '1234-ABCD' } do
+
+      # context is provided by component_helper, its default values are provided by 'describe' metadata, and
+      # customized through test's metadata
+      subject(:released) do
+        component = IBMJdk.new(context)
+        component.detect
+        component.release
+      end
+
+      it 'should add appropriate TLS options for Java 1.8', java_opts: [], service_release: '1.8.0' do
+        expect(released).to include('-Dcom.ibm.jsse2.overrideDefaultTLS=true')
+        expect(released).not_to include('-Dcom.ibm.jsse2.overrideDefaultProtocol=SSL_TLSv2')
+      end
+
+      it 'should add appropriate TLS options for Java 1.7', java_opts: [], service_release: '1.7.1' do
+        expect(released).to include('-Dcom.ibm.jsse2.overrideDefaultTLS=true')
+        expect(released).to include('-Dcom.ibm.jsse2.overrideDefaultProtocol=SSL_TLSv2')
+      end
+
+    end
   end
 
 end


### PR DESCRIPTION
* Set `-Dcom.ibm.jsse2.overrideDefaultTLS=true` to behave like OpenJDK and enable all TLS protocols when `SSLContext.getInstance("TLS")` is called. See [Matching the behavior of SSLContext.getInstance("TLS") to Oracle](https://www.ibm.com/support/knowledgecenter/SSYKE2_7.0.0/com.ibm.java.security.component.70.doc/security-component/jsse2Docs/matchsslcontext_tls.html) for details.
* Set `-Dcom.ibm.jsse2.overrideDefaultProtocol=SSL_TLSv2` for 1.7.x to enable all TLS protocols when `SSLContext.getDefault()` is called. See [Overriding the SSL protocol defined by the default SSL socket factory](https://www.ibm.com/support/knowledgecenter/SSYKE2_7.0.0/com.ibm.java.security.component.70.doc/security-component/jsse2Docs/overrideSSLprotocol.html) for details.
