### PR TITLE
Restore MariaDB JDBC driver range

### DIFF
--- a/lib/liberty_buildpack/services/config/mysql.yml
+++ b/lib/liberty_buildpack/services/config/mysql.yml
@@ -31,5 +31,5 @@ client_jars : 'mariadb-java-client*.jar|mysql-connector-java*.jar'
 service_filter : 'mysql|cleardb'
 
 driver:
-  version: 1.4.+
+  version: 1.+
   repository_root: "https://download.run.pivotal.io/mariadb-jdbc"


### PR DESCRIPTION
The [CONJ-347](https://jira.mariadb.org/browse/CONJ-347) problem has been fixed and new MariaDB JDBC driver 1.5.3 has been released, so update the version range to pick up the latest 1.5 release.
