### PR TITLE
Monitor apps with explicit names

### DIFF
--- a/lib/liberty_buildpack/container/liberty.rb
+++ b/lib/liberty_buildpack/container/liberty.rb
@@ -485,7 +485,12 @@ module LibertyBuildpack::Container
     end
 
     def appstate_apps(server_xml_doc)
-      REXML::XPath.match(server_xml_doc, '/server/application | /server/webApplication | /server/enterpriseApplication')
+      apps = REXML::XPath.match(server_xml_doc, '/server/application | /server/webApplication | /server/enterpriseApplication')
+      app_names = []
+      apps.each do |app|
+        app_names << app.attributes['name'] unless app.attributes['name'].nil?
+      end
+      app_names
     end
 
     def check_appstate_feature(server_xml_doc)
@@ -503,14 +508,7 @@ module LibertyBuildpack::Container
 
         # Set the apps to be monitored.
         appstate = REXML::Element.new('appstate2', server_xml_doc.root)
-
-        app_names = []
-
-        apps.each do |app|
-          app_names << app.attributes['name'] unless app.attributes['name'].nil?
-        end
-
-        appstate.add_attribute('appName', app_names.join(', '))
+        appstate.add_attribute('appName', apps.join(', '))
       end
     end
 

--- a/spec/liberty_buildpack/container/liberty_spec.rb
+++ b/spec/liberty_buildpack/container/liberty_spec.rb
@@ -1352,9 +1352,12 @@ module LibertyBuildpack::Container
         check_no_appstate('<application name="myapp" />', configuration)
       end
 
-      it 'should NOT add appstate2 when server xml does not contain application and appstate is enabled' do
-        configuration = default_configuration
-        check_no_appstate('', configuration)
+      it 'should NOT add appstate2 when server xml does not contain application' do
+        check_no_appstate('')
+      end
+
+      it 'should NOT add appstate2 when server xml contains application without name' do
+        check_no_appstate('<application location="myapp" />')
       end
 
     end


### PR DESCRIPTION
Additional `appstate` improvements: monitor application with explicit names only. Replaces #326.
