### PR TITLE
Improve order of parameters for agentlib

### DIFF
--- a/lib/liberty_buildpack/framework/dynatrace_one_agent.rb
+++ b/lib/liberty_buildpack/framework/dynatrace_one_agent.rb
@@ -163,7 +163,7 @@ module LibertyBuildpack::Framework
     #------------------------------------------------------------------------------------------
     def get_service_options(credentials)
       begin
-        @dynatrace_options = "#{SERVER}=#{server(credentials)},#{TENANT}=#{tenant(credentials)},#{TENANTTOKEN}=#{tenanttoken(credentials)}"
+        @dynatrace_options = "#{TENANT}=#{tenant(credentials)},#{TENANTTOKEN}=#{tenanttoken(credentials)},#{SERVER}=#{server(credentials)}"
       rescue => e
         @logger.error("Unable to process the service options for the Dynatrace OneAgent framework. #{e.message}")
       end
@@ -252,7 +252,7 @@ module LibertyBuildpack::Framework
       dynatrace_one_agent_manifest = File.join(@app_dir, DYNATRACE_HOME_DIR, 'manifest.json')
       @logger.debug { "File exists?: #{dynatrace_one_agent_manifest} #{File.file?(dynatrace_one_agent_manifest)}" }
       endpoints = JSON.parse(File.read(dynatrace_one_agent_manifest))['communicationEndpoints']
-      endpoints.join('\;')
+      endpoints.join(';')
     end
 
     def tenant(credentials)

--- a/spec/liberty_buildpack/framework/dynatrace_one_agent_spec.rb
+++ b/spec/liberty_buildpack/framework/dynatrace_one_agent_spec.rb
@@ -257,7 +257,7 @@ module LibertyBuildpack::Framework
 
       it 'should return command line options for a valid service in a default container' do
         pwd = ENV['PWD']
-        pattern = "^(-agentpath:#{pwd}/app/#{dynatrace_home}/agent/.*/libruxitagentloader.so=server=https://test-tenant.live.dynatrace.com,tenant=test-tenant,tenanttoken=test-token.*)$"
+        pattern = "^(-agentpath:#{pwd}/app/#{dynatrace_home}/agent/.*/libruxitagentloader.so=tenant=test-tenant,tenanttoken=test-token,server=https://test-tenant.live.dynatrace.com.*)$"
 
         expect(released[0]).to match(/#{pattern}/)
       end


### PR DESCRIPTION
This PR provides a workaround for a overly long agentlib parameter string that gets truncated by IBM java after 512 chars. The workaround only puts the most important KV pairs at the beginning of the string so that a truncation at 512 chars doesn't harm correct agent connectivity.