### PR TITLE
Export agent connection info to circumvent IBM Java parameter truncation

### DIFF
--- a/spec/liberty_buildpack/framework/dynatrace_one_agent_spec.rb
+++ b/spec/liberty_buildpack/framework/dynatrace_one_agent_spec.rb
@@ -257,7 +257,7 @@ module LibertyBuildpack::Framework
 
       it 'should return command line options for a valid service in a default container' do
         pwd = ENV['PWD']
-        pattern = "^(-agentpath:#{pwd}/app/#{dynatrace_home}/agent/.*/libruxitagentloader.so=tenant=test-tenant,tenanttoken=test-token,server=https://test-tenant.live.dynatrace.com.*)$"
+        pattern = "^(-agentpath:#{pwd}/app/#{dynatrace_home}/agent/.*/libruxitagentloader.so.*)$"
 
         expect(released[0]).to match(/#{pattern}/)
       end


### PR DESCRIPTION
This PR circumvents the IBM java issue of limiting parameters to 512 chars. The integration was updated to set agent connection information by means of environment variables. 