### PR TITLE
Add Contrast Security framework support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ All Documentation is available in the Docs folder of the buildpack.
     * [DistZip](docs/container-distZip.md)
 * Frameworks
     * [AppDynamics Agent](docs/framework-app_dynamics_agent.md)
+    * [Contrast Security Agent](docs/framework-contrast-security-agent.md)
     * [Dynatrace Appmon Agent](docs/framework-dynatrace_appmon_agent.md)
     * [Dynatrace SaaS/Managed OneAgent](docs/framework-dynatrace_one_agent.md)
     * [DynamicPULSE Agent](docs/framework-dynamic_pulse_agent.md)

--- a/config/components.yml
+++ b/config/components.yml
@@ -33,3 +33,4 @@ frameworks:
   - "LibertyBuildpack::Framework::DynatraceOneAgent"
   - "LibertyBuildpack::Framework::DynamicPULSEAgent"
   - "LibertyBuildpack::Framework::ContainerCertificateTrustStore"
+  - "LibertyBuildpack::Framework::ContrastSecurityAgent"

--- a/config/contrastsecurityagent.yml
+++ b/config/contrastsecurityagent.yml
@@ -1,0 +1,19 @@
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2014-2017 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Service configuration
+---
+version: 3.+
+repository_root: https://artifacts.contrastsecurity.com/agents/java

--- a/docs/framework-contrast-security-agent.md
+++ b/docs/framework-contrast-security-agent.md
@@ -1,0 +1,43 @@
+# Contrast Security Agent Framework
+The Contrast Security Agent Framework causes an application to be automatically configured to work with a bound [Contrast Security Service][].
+
+<table>
+  <tr>
+    <td><strong>Detection Criterion</strong></td><td>Existence of a single Contrast Security service is defined as the <a href="http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES"><code>VCAP_SERVICES</code></a> payload containing at least one of the following:
+      <ul>
+        <li>name that has the substring <code>contrast-security</code>. <strong>Note: </strong> This is only applicable to user-provided services</li>
+        <li>label that has the substring <code>contrast-security</code>.</li>
+        <li>tags that have the substring <code>contrast-security</code>.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Tags</strong></td><td><tt>contrast-security</tt></td>
+  </tr>
+</table>
+Tags are printed to standard output by the Buildpack detect script.
+
+## User-Provided Service (Optional)
+Users may optionally provide their own Contrast Security service. A user-provided Contrast Security service must have a name or tag with `contrast-security` in it so that the Contrast Security Agent Framework will automatically configure the application to work with the service.
+
+The credential payload of the service must contain the following entries:
+
+| Name | Description
+| ---- | -----------
+| `username`    | A user with application onboarding permission
+| `api_key`     | The user's api key
+| `service_key` | The user's service key
+| `teamserver_url` | The url to your Teamserver instance
+
+## Configuration
+The framework can be configured by modifying the [`config/contrastsecurityagent.yml`][] file in the buildpack fork.  
+
+| Name | Description
+| ---- | -----------
+| `repository_root` | The URL of the Contrast Security repository index.
+
+[Configuration and Extension]: ../README.md#configuration-and-extension
+[`config/contrastsecurityagent.yml`]: ../config/contrast_security_agent.yml
+[Contrast Security Service]: https://www.contrastsecurity.com
+[repositories]: extending-repositories.md
+[version syntax]: extending-repositories.md#version-syntax-and-ordering

--- a/lib/liberty_buildpack/framework/contrast_security_agent.rb
+++ b/lib/liberty_buildpack/framework/contrast_security_agent.rb
@@ -1,0 +1,205 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2017 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'liberty_buildpack/diagnostics/logger_factory'
+require 'liberty_buildpack/framework'
+require 'liberty_buildpack/repository/configured_item'
+require 'liberty_buildpack/util/download'
+require 'liberty_buildpack/container/common_paths'
+require 'liberty_buildpack/services/vcap_services'
+require 'fileutils'
+require 'rexml/document'
+
+module LibertyBuildpack::Framework
+
+  #------------------------------------------------------------------------------------
+  # The ContrastSecurityAgent class that provides Contrast Security Agent resources as a framework to applications
+  #------------------------------------------------------------------------------------
+  class ContrastSecurityAgent
+
+    #-----------------------------------------------------------------------------------------
+    # Creates an instance, passing in a context of information available to the component
+    #
+    # @param [Hash] context the context that is provided to the instance
+    # @option context [String] :app_dir the directory that the application exists in
+    # @option context [Hash] :configuration the properties provided by the user
+    # @option context [CommonPaths] :common_paths the set of paths common across components that components should reference`
+    # @option context [Hash] :vcap_services the services bound to the application provided by cf
+    # @option context [Array<String>] :java_opts an array that Java options can be added to
+    #-----------------------------------------------------------------------------------------
+    def initialize(context = {})
+      @logger = LibertyBuildpack::Diagnostics::LoggerFactory.get_logger
+      @app_dir = context[:app_dir]
+      @vcap_application = context[:vcap_application]
+      @configuration = context[:configuration]
+      @common_paths = context[:common_paths] || LibertyBuildpack::Container::CommonPaths.new
+      @vcap_services = context[:vcap_services]
+      @services = @vcap_services ? LibertyBuildpack::Services::VcapServices.new(@vcap_services) : LibertyBuildpack::Services::VcapServices.new({})
+      @java_opts = context[:java_opts]
+    end
+
+    #-----------------------------------------------------------------------------------------
+    # Determines if the application's VCAP environment and the configured contrast security configuration
+    # is available for the contrast security framework to provide a configured contrast security agent. Valid
+    # detect is based on VCAP_SERVICES, VCAP_APPLICATION, and the repository root index.yml
+    # defined by the contrast security configuration.
+    #
+    # @return [String] the detected versioned ID if the environment and config are valid, otherwise nil
+    #------------------------------------------------------------------------------------------
+    def detect
+      contrast_service_exist? ? process_config : nil
+    end
+
+    #-----------------------------------------------------------------------------------------
+    # Create the contrast directory and its contents for the app droplet.
+    #------------------------------------------------------------------------------------------
+    def compile
+      if @app_dir.nil?
+        raise 'app directory must be provided' if @app_dir.nil?
+      elsif @version.nil? || @uri.nil?
+        raise "Version #{@version} or uri #{@uri} is not available, detect needs to be invoked"
+      end
+
+      # create a contrast home dir in the droplet
+      contrast_home = File.join(@app_dir, CONTRAST_DIR)
+      FileUtils.mkdir_p(contrast_home)
+
+      write_configuration(@services.find_service(CONTRAST_FILTER)['credentials'])
+      download_agent(@version, @uri, jar_name, contrast_home)
+    end
+
+    #-----------------------------------------------------------------------------------------
+    # Processes the contrast security configuration to obtain the corresponding version and uri of the
+    # contrast security agent jar in the repository root. If the configuration can be processed and the
+    # uri contains a valid contrast security agent jar name, the versioned ID is returned and configuration
+    # data is initialized.
+    #
+    # @return [String] the contrast security version ID
+    #------------------------------------------------------------------------------------------
+    def process_config
+      begin
+        @version, @uri = LibertyBuildpack::Repository::ConfiguredItem.find_item(@configuration)
+      rescue => e
+        @logger.error("Unable to process the configuration for the Contrast Security Agent framework. #{e.message}")
+      end
+
+      @version.nil? ? nil : version_identifier
+    end
+
+    #-----------------------------------------------------------------------------------------
+    # Create the contrast security agent options appended as java_opts.
+    #------------------------------------------------------------------------------------------
+    def release
+      # Contrast paths within the droplet
+      app_dir = @common_paths.relative_location
+      contrast_home_dir = File.join(app_dir, CONTRAST_DIR)
+      contrast_agent = File.join(contrast_home_dir, jar_name)
+      contrast_config = File.join(contrast_home_dir, CONTRAST_CONFIG_NAME)
+
+      # specify contrast java options
+      @java_opts << "-javaagent:#{contrast_agent}=#{contrast_config}"
+      @java_opts << "-Dcontrast.dir=#{contrast_home_dir}"
+      @java_opts << "-Dcontrast.override.appname=#{vcap_app_name}"
+    end
+
+    private
+
+    API_KEY = 'api_key'.freeze
+    CONTRAST_CONFIG_NAME = 'contrast.config'.freeze
+    CONTRAST_DIR = '.contrast'.freeze
+    CONTRAST_FILTER = 'contrast-security'.freeze
+    PLUGIN_PACKAGE = 'com.aspectsecurity.contrast.runtime.agent.plugins.'.freeze
+    SERVICE_KEY = 'service_key'.freeze
+    TEAMSERVER_URL = 'teamserver_url'.freeze
+    USERNAME = 'username'.freeze
+
+    def jar_name
+      "#{version_identifier}.jar"
+    end
+
+    def version_identifier
+      "contrast-engine-#{@version.to_s.split('_')[0]}"
+    end
+
+    #-----------------------------------------------------------------------------------------
+    # Determines if the Contrast Security service is included in VCAP_SERVICES
+    #
+    # @return [Boolean]  true if the app is bound to a contrast-security service
+    #------------------------------------------------------------------------------------------
+    def contrast_service_exist?
+      @services.one_service?(CONTRAST_FILTER, TEAMSERVER_URL, USERNAME, API_KEY, SERVICE_KEY)
+    end
+
+    def add_contrast(doc, credentials)
+      contrast = doc.add_element('contrast')
+      (contrast.add_element 'id').add_text('default')
+      (contrast.add_element 'global-key').add_text(credentials[API_KEY])
+      (contrast.add_element 'url').add_text("#{credentials[TEAMSERVER_URL]}/Contrast/s/")
+      (contrast.add_element 'results-mode').add_text('never')
+
+      add_user contrast, credentials
+      add_plugins contrast
+    end
+
+    def add_plugins(contrast)
+      plugin_group = contrast.add_element('plugins')
+
+      (plugin_group.add_element 'plugin').add_text("#{PLUGIN_PACKAGE}.security.SecurityPlugin")
+      (plugin_group.add_element 'plugin').add_text("#{PLUGIN_PACKAGE}.architecture.ArchitecturePlugin")
+      (plugin_group.add_element 'plugin').add_text("#{PLUGIN_PACKAGE}.appupdater.ApplicationUpdatePlugin")
+      (plugin_group.add_element 'plugin').add_text("#{PLUGIN_PACKAGE}.sitemap.SitemapPlugin")
+      (plugin_group.add_element 'plugin').add_text("#{PLUGIN_PACKAGE}.frameworks.FrameworkSupportPlugin")
+      (plugin_group.add_element 'plugin').add_text("#{PLUGIN_PACKAGE}.http.HttpPlugin")
+    end
+
+    def add_user(contrast, credentials)
+      user = contrast.add_element('user')
+      (user.add_element 'id').add_text(credentials[USERNAME])
+      (user.add_element 'key').add_text(credentials[SERVICE_KEY])
+    end
+
+    def contrast_config
+      File.join(@app_dir, CONTRAST_DIR, CONTRAST_CONFIG_NAME)
+    end
+
+    def write_configuration(credentials)
+      doc = REXML::Document.new
+
+      add_contrast doc, credentials
+
+      File.open(contrast_config, 'w+') { |f| f.write(doc) }
+    end
+
+    #-----------------------------------------------------------------------------------------
+    # Download the agent library from the repository as specified in the contrast security configuration.
+    #------------------------------------------------------------------------------------------
+    def download_agent(version_desc, uri_source, target_jar_name, target_dir)
+      LibertyBuildpack::Util.download(version_desc, uri_source, 'Contrast Security Agent', target_jar_name, target_dir)
+    rescue => e
+      raise "Unable to download the Contrast Security Agent jar. Ensure that the agent jar at #{uri_source} is available and accessible. #{e.message}"
+    end
+
+    #-----------------------------------------------------------------------------------------
+    # The application name that's made available from VCAP_APPLICATION.
+    #
+    # @return [String] the application name from VCAP_APPLICATION
+    #------------------------------------------------------------------------------------------
+    def vcap_app_name
+      @vcap_application['application_name']
+    end
+
+  end
+end

--- a/spec/liberty_buildpack/framework/contrast_security_agent_spec.rb
+++ b/spec/liberty_buildpack/framework/contrast_security_agent_spec.rb
@@ -1,0 +1,259 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2017 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+require 'spec_helper'
+require 'component_helper'
+require 'liberty_buildpack/framework/contrast_security_agent'
+require 'liberty_buildpack/container/common_paths'
+
+module LibertyBuildpack::Framework
+
+  describe 'ContrastSecurityAgent' do
+    include_context 'component_helper' # component context
+
+    # test data
+    let(:contrast_security_home) { '.contrast' } # the expected staged contrast security agent directory
+    let(:application_cache) { double('ApplicationCache') }
+    let(:version) { '3.4.1' }
+    let(:versionid) { "contrast-engine-#{version}" }
+    let(:jar_name) { "contrast-engine-#{version}.jar" }
+    let(:config_name) { 'contrast.config' }
+
+    before do |example|
+      # an index.yml entry returned from the index.yml of the contrast security repository
+      if example.metadata[:index_version]
+        # contrast security index.yml info provided by tests
+        index_version = example.metadata[:index_version]
+        index_uri = example.metadata[:index_uri]
+        index_license = example.metadata[:index_license]
+      else
+        # default values for the contrast security index.yml info for tests
+        index_version = version
+        index_uri = "https://downloadsite/contrast-security/#{versionid}.jar"
+      end
+
+      # By default, always stub the return of a valid index.yml entry
+      find_item = example.metadata[:return_find_item].nil? ? true : example.metadata[:return_find_item]
+      if find_item
+        index_yml_entry = [LibertyBuildpack::Util::TokenizedVersion.new(index_version), index_uri, index_license]
+        LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item).and_return(index_yml_entry)
+      else
+        # tests can set find_item=false and a raise_error_message to mock a failed return of processing the index.yml
+        LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item).and_raise(example.metadata[:raise_error_message])
+      end
+
+      # For a download request of a contrast security agent jar, return the fixture jar
+      LibertyBuildpack::Util::Cache::ApplicationCache.stub(:new).and_return(application_cache)
+      application_cache.stub(:get).with(index_uri).and_yield(File.open('spec/fixtures/stub-contrast-security-agent.jar'))
+    end
+
+    describe 'configuration' do
+      it 'must have v3.+ as the configured version' do
+        configuration = YAML.load_file(File.expand_path('../../../config/contrastsecurityagent.yml', File.dirname(__FILE__)))
+
+        expected_version = LibertyBuildpack::Util::TokenizedVersion.new('3.4.1')
+        actual_version = LibertyBuildpack::Repository::ConfiguredItem.find_item(configuration)[0]
+
+        expect(actual_version).to eq(expected_version)
+      end
+    end
+
+    describe 'detect',
+             vcap_application_context: { 'application_version' => '12345678-a123-4b567-89c0-87654321abcde',
+                                         'application_name' => 'TestApp', 'application_uris' => ['TestApp.the.domain'] } do
+
+      subject(:detected) do
+        ContrastSecurityAgent.new(context).detect
+      end
+
+      context 'user provided service' do
+        def_type = 'servicetype'
+        def_name = 'servicename'
+        def_label = 'user-provided'
+        def_tags = ['atag']
+        def_credentials = { 'teamserver_url' => 'https://example.com', 'api_key' => 'test', 'service_key' => 'test', 'username' => 'test_user' }
+
+        it 'should be detected when the service name includes contrast-security substring',
+           vcap_services_context: { def_type => [{ 'name' => 'contrast-security', 'label' => def_label, 'tags' => def_tags,
+                                                   'credentials' => def_credentials }] } do
+          expect(detected).to eq(versionid)
+        end
+
+        it 'should raise a runtime error for multiple valid contrast security user services',
+           vcap_services_context: { def_type => [{ 'name' => 'contrast-security', 'label' => def_label, 'tags' => def_tags,
+                                                   'credentials' => def_credentials }],
+                                    'servicetype2' => [{ 'name' => 'contrast-security', 'label' => def_label, 'tags' => def_tags,
+                                                         'credentials' => def_credentials }] } do
+
+          expect { detected }.to raise_error(RuntimeError)
+        end
+
+        it 'should be detected when the tag includes contrast-security substring',
+           vcap_services_context: { def_type => [{ 'name' => def_name, 'label' => def_label, 'tags' => ['contrast-security'],
+                                                   'credentials' => def_credentials }] } do
+          expect(detected).to eq(versionid)
+        end
+
+        it 'should not be detected unless the name or tag includes contrast security substring',
+           vcap_services_context: { def_type => [{ 'name' => def_name, 'label' => def_label, 'tags' => def_tags,
+                                                   'credentials' => def_credentials }] } do
+          expect(detected).to eq(nil)
+        end
+      end
+
+      context 'application with no services' do
+        it 'should not detect the contrast security service',
+           vcap_services_context: {} do
+          expect(detected).to eq(nil)
+        end
+      end
+
+      context 'application with one service' do
+        def_credentials = { 'teamserver_url' => 'https://example.com', 'api_key' => 'test', 'service_key' => 'test', 'username' => 'test_user' }
+        it 'should be detected when an application has a valid service attribute that includes contrast-security',
+           vcap_services_context: { 'contrast-security' => [{ 'name' => 'test-contrast-security', 'label' => 'contrast-security',
+                                                              'credentials' => def_credentials }] } do
+
+          expect(detected).to eq(versionid)
+        end
+
+        it 'should not be detected if contrast security service does not exist',
+           vcap_services_context: { 'mysql' => [{ 'name' => 'test-mysql', 'label' => 'mysql',
+                                                  'credentials' => { 'licenseKey' => '9876543210fedcba' } }] } do
+
+          expect(detected).to eq(nil)
+        end
+
+        it 'should not be detected since name is not used as a match check unless it is a user service',
+           vcap_services_context: { 'mysql' => [{ 'name' => 'test-contrast security', 'label' => 'mysql',
+                                                  'credentials' => def_credentials }] } do
+
+          expect(detected).to eq(nil)
+        end
+      end
+
+      context 'application with multiple services' do
+        def_credentials = { 'teamserver_url' => 'https://example.com', 'api_key' => 'test', 'service_key' => 'test', 'username' => 'test_user' }
+        it 'should be detected if one of the services is contrast security',
+           vcap_services_context: { 'mysql' => [{ 'name' => 'test-mysql', 'label' => 'mysql',
+                                                  'credentials' => { 'licenseKey' => '9876543210fedcba' } }],
+                                    'contrast-security' => [{ 'name' => 'contrast-security', 'label' => 'contrast-security',
+                                                              'credentials' => def_credentials }] } do
+
+          expect(detected).to eq(versionid)
+        end
+
+        it 'should raise a runtime error if multiple contrast security services exist',
+           vcap_services_context: { 'contrast-security-key1' => [{ 'name' => 'test-name', 'label' => 'contrast-security',
+                                                                   'credentials' => { 'licenseKey' => 'abcdef0123456789' } }],
+                                    'contrast-security-key2' => [{ 'name' => 'test-name', 'label' => 'contrast-security',
+                                                                   'credentials' => def_credentials }] } do
+
+          expect { detected }.to raise_error(RuntimeError)
+        end
+
+        it 'should not be detected if none of the services is contrast security',
+           vcap_services_context: { 'mysql' => [{ 'name' => 'test-mysql', 'label' => 'mysql',
+                                                  'credentials' => { 'licenseKey' => '9876543210fedcba' } }],
+                                    'sqldb' => [{ 'name' => 'test-sqldb', 'label' => 'sqldb',
+                                                  'credentials' => {} }] } do
+
+          expect(detected).to eq(nil)
+        end
+      end
+
+      context 'invalid index.yml entry with a valid contrast security service',
+              vcap_services_context: { 'contrast security' => [{ 'name' => 'test-contrast-security', 'label' => 'contrast-security',
+                                                                 'credentials' => { 'licenseKey' => 'abcdef0123456789' } }] } do
+
+        it 'should raise an error including the underlying failure if the index.yml could not be processed',
+           return_find_item: false, raise_error_message: 'underlying index.yml error' do
+          expect(detected).to eq(nil)
+        end
+
+      end
+
+    end # end of detect tests
+
+    describe 'compile',
+             vcap_application_context: { 'application_version' => '12345678-a123-4b567-89c0-87654321abcde',
+                                         'application_name' => 'TestApp', 'application_uris' => ['TestApp.the.domain'] },
+             vcap_services_context: { 'contrast-security' => [{ 'name' => 'test-contrast-security', 'label' => 'contrast-security',
+                                                                'credentials' => { 'teamserver_url' => 'https://test.com', 'username' => 'aUser', 'api_key' => 'test', 'service_key' => 'test' } }] } do
+
+      subject(:compiled) do
+        contrast = ContrastSecurityAgent.new(context)
+        contrast.detect
+        contrast.compile
+      end
+
+      it 'should have a contrast security agent configuration file in the droplet' do
+        compiled
+        expect(File.exist?(File.join(app_dir, contrast_security_home, 'contrast.config'))).to eq(true)
+      end
+
+      it 'should create a contrast security home directory in the application root' do
+        compiled
+        expect(File.exist?(File.join(app_dir, contrast_security_home))).to eq(true)
+      end
+
+      describe 'download agent jar based on index.yml information' do
+        it 'should download the agent with a matching key and jar version' do
+          expect { compiled }.to output(%r{Downloading Contrast Security Agent #{version} from https://downloadsite/contrast-security/contrast-engine-#{version}.jar}).to_stdout
+          expect(File.exist?(File.join(app_dir, contrast_security_home, jar_name))).to eq(true)
+        end
+
+        it 'should raise an error with original exception if the jar could not be downloaded',
+           index_version: '0.0.0', index_uri: 'https://downloadsite/contrast-security/contrast-security-0.0.0.jar' do
+          allow(LibertyBuildpack::Util).to receive(:download).and_raise('underlying download error')
+          expect { compiled }.to raise_error(/Unable to download the Contrast Security Agent jar..+underlying download error/)
+        end
+      end
+    end # end compile
+
+    describe 'release',
+             java_opts: [],
+             vcap_application_context: { 'application_version' => '12345678-a123-4b567-89c0-87654321abcde',
+                                         'application_name' => 'TestApp', 'application_uris' => ['TestApp.the.domain'] },
+             vcap_services_context: { 'contrast-security' => [{ 'name' => 'test-contrast-security', 'label' => 'contrast-security',
+                                                                'credentials' => { 'teamserver_url' => 'a', 'username' => 'a', 'api_key' => 'a', 'service_key' => 'c' } }] } do
+
+      subject(:released) do
+        contrast = ContrastSecurityAgent.new(context)
+        contrast.detect
+        contrast.release
+      end
+
+      it 'should return command line options for a valid service in a default container' do
+        expect(released).to include("-javaagent:./#{contrast_security_home}/#{jar_name}=./#{contrast_security_home}/#{config_name}")
+        expect(released).to include("-Dcontrast.dir=./#{contrast_security_home}")
+        expect(released).to include('-Dcontrast.override.appname=TestApp')
+      end
+
+      it 'should return command line options for a valid service in a container with an adjusted relative location',
+         common_paths: LibertyBuildpack::Container::CommonPaths.new do |example|
+
+        example.metadata[:common_paths].relative_location = 'custom/container/dir'
+
+        expect(released).to include("-javaagent:../../../#{contrast_security_home}/#{jar_name}=../../../#{contrast_security_home}/#{config_name}")
+        expect(released).to include("-Dcontrast.dir=../../../#{contrast_security_home}")
+        expect(released).to include('-Dcontrast.override.appname=TestApp')
+
+      end
+    end # end of release
+
+  end
+end # module


### PR DESCRIPTION
This pr adds support for using Contrast Security's Java agent.
A bound service will be used to create a configuration file for the agent, as well as set some Java system properties.
