### PR TITLE
Contrast Security - Referral Tile Support

### DIFF
--- a/docs/framework-contrast-security-agent.md
+++ b/docs/framework-contrast-security-agent.md
@@ -8,6 +8,7 @@ The Contrast Security Agent Framework causes an application to be automatically 
         <li>name that has the substring <code>contrast-security</code>. <strong>Note: </strong> This is only applicable to user-provided services</li>
         <li>label that has the substring <code>contrast-security</code>.</li>
         <li>tags that have the substring <code>contrast-security</code>.</li>
+        <li>credential payload containing the key <code>contrast_referral_tile<code></li>
       </ul>
     </td>
   </tr>

--- a/lib/liberty_buildpack/framework/contrast_security_agent.rb
+++ b/lib/liberty_buildpack/framework/contrast_security_agent.rb
@@ -77,7 +77,7 @@ module LibertyBuildpack::Framework
       contrast_home = File.join(@app_dir, CONTRAST_DIR)
       FileUtils.mkdir_p(contrast_home)
 
-      write_configuration(@services.find_service(CONTRAST_FILTER)['credentials'])
+      write_configuration(find_service['credentials'])
       download_agent(@version, @uri, jar_name, contrast_home)
     end
 
@@ -122,6 +122,7 @@ module LibertyBuildpack::Framework
     CONTRAST_DIR = '.contrast'.freeze
     CONTRAST_FILTER = 'contrast-security'.freeze
     PLUGIN_PACKAGE = 'com.aspectsecurity.contrast.runtime.agent.plugins.'.freeze
+    REFERRAL_TILE = 'contrast_referral_tile'.freeze
     SERVICE_KEY = 'service_key'.freeze
     TEAMSERVER_URL = 'teamserver_url'.freeze
     USERNAME = 'username'.freeze
@@ -140,7 +141,7 @@ module LibertyBuildpack::Framework
     # @return [Boolean]  true if the app is bound to a contrast-security service
     #------------------------------------------------------------------------------------------
     def contrast_service_exist?
-      @services.one_service?(CONTRAST_FILTER, TEAMSERVER_URL, USERNAME, API_KEY, SERVICE_KEY)
+      @services.one_service?(CONTRAST_FILTER, TEAMSERVER_URL, USERNAME, API_KEY, SERVICE_KEY) || !referral_tile.nil?
     end
 
     def add_contrast(doc, credentials)
@@ -199,6 +200,20 @@ module LibertyBuildpack::Framework
     #------------------------------------------------------------------------------------------
     def vcap_app_name
       @vcap_application['application_name']
+    end
+
+    def referral_tile
+      @services.find do |service|
+        service['credentials'].key?(REFERRAL_TILE)
+      end
+    end
+
+    def find_service
+      if @services.one_service?(CONTRAST_FILTER, TEAMSERVER_URL, USERNAME, API_KEY, SERVICE_KEY)
+        @services.find_service(CONTRAST_FILTER)
+      else
+        referral_tile
+      end
     end
 
   end

--- a/spec/liberty_buildpack/framework/contrast_security_agent_spec.rb
+++ b/spec/liberty_buildpack/framework/contrast_security_agent_spec.rb
@@ -112,6 +112,13 @@ module LibertyBuildpack::Framework
                                                    'credentials' => def_credentials }] } do
           expect(detected).to eq(nil)
         end
+
+        it 'should detect a referral tile created user provided service',
+           vcap_services_context: { def_type => [{ 'name' => def_name, 'label' => def_label, 'tags' => def_tags,
+                                                   'credentials' => { 'contrast_referral_tile' => 'true' } }] } do
+
+          expect(detected).to eq(versionid)
+        end
       end
 
       context 'application with no services' do


### PR DESCRIPTION
This adds an extra detection criterion to the contrast agent framework to check all bound services for a 'contrast_referral_tile' key.
(even if the service name doesn't match the normal filter of contrast-security) for usage with referral tiles where the user provided service may or may not have the appropriate name.