### PR TITLE
JRE Version Issue Fixes

### DIFF
--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -47,8 +47,8 @@ module LibertyBuildpack
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }
                     #.max { |a, b| a <=> b }
 
-          puts "LET'S SEE #{version}"
-          
+          #puts "LET'S SEE #{version}"
+
           version
         end
 

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -51,9 +51,10 @@ module LibertyBuildpack
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }
                     .max { |a, b|
                       a.zip(b).each do |c, d|
-                        if !/\A\d+\z/.match(c.to_s)
+                        if !/\A\d+\z/.match(c)
                           #Eliminating the letters (except ifx) for the string num in order to facilitate comparison
                           newNum = c.dup
+                          puts "TESTING: #{newNum}"
                           if newNum.include? "ifx"
                               newNum = newNum.gsub!("ifx", ".5")
                           end

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -49,10 +49,39 @@ module LibertyBuildpack
 
           version = tokenized_versions
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }
-                    .max { |a, b| a <=> b }
+                    .max { |a, b|
+                      ver1.zip(ver2).each do |a, b|
+                        if !/\A\d+\z/.match(a)
+                          #Eliminating the letters (except ifx) for the string num in order to facilitate comparison
+                          newNum = a.dup
+                          if newNum.include? "ifx"
+                              newNum = newNum.gsub!("ifx", ".5")
+                          end
+                          newNum = newNum.gsub!(/[a-zA-Z]/, " ")
+                          newNum = newNum.gsub!("_", " ")
+                          numArr = newNum.split(" ")
+                          puts "IMPRIME: #{numArr} como estaba antes: #{a}"
+                          #Eliminating the letters (except ifx) for the string in b in order to facilitate comparison
+                          newNum2 = b.dup
+                          if newNum2.include? "ifx"
+                              newNum2 = newNum2.gsub!("ifx", ".5")
+                          end
+                          newNum2 = newNum2.gsub!(/[a-zA-Z]/, " ")
+                          newNum2 = newNum2.gsub!("_", " ")
+                          numArr2 = newNum2.split(" ")
+                          puts "Going to compare #{numArr2} that was #{b} originally vs #{numArr} that was #{a} originally"
+                          #Compare each number now from left to right
 
-          puts "LET'S SEE #{tokenized_versions
-                    .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }}"
+                          numArr.zip(numArr2).each do |first, second|
+                              next unless (first.to_f <=> second.to_f) != 0
+                              puts "End result: #{first.to_f <=> second.to_f}"
+                              break
+                          end
+                        else
+                            next unless (a.to_i <=> b.to_i) != 0
+                            puts "End result: #{a.to_i <=> b.to_i}"
+                        end
+                      end }
 
           version
         end

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -71,7 +71,7 @@ module LibertyBuildpack
                 return first.to_f <=> second.to_f
               end
             else
-              c = '0.' + c if c[0] == '0' && c.length > 1 # verify leading 0s if the number is more than one digit.
+              c = '0.' + c if c[0] == '0' && c.length > 1 # verify if there are leading 0s in order to determine it's a decimal number and treat it as such
 
               d = '0.' + d if d[0] == '0' && d.length > 1
 

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -41,7 +41,7 @@ module LibertyBuildpack
           tokenized_candidate_version = safe_candidate_version candidate_version
           tokenized_versions          = versions.map { |version| create_token(version) }.compact
 
-          puts "HERE: #{tokenized_versions.pop}"
+          puts "HERE: #{tokenized_versions.pop}" if (tokenized_versions.pop == "1.8.0.sr5")
 
           version = tokenized_versions
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -99,7 +99,7 @@ module LibertyBuildpack
                   newNum = newNum.gsub!("ifx", ".5")
               end
               newNum = newNum.gsub!(/[a-zA-Z]/, " ")
-              puts "TESTING: #{newNum}"
+              #puts "TESTING: #{newNum}"
 
               if newNum.include? "_"
                 newNum = newNum.gsub!("_", " ")
@@ -113,18 +113,18 @@ module LibertyBuildpack
                   newNum2 = newNum2.gsub!("ifx", ".5")
               end
               newNum2 = newNum2.gsub!(/[a-zA-Z]/, " ")
-              puts "TESTING: #{newNum2}"
+              #puts "TESTING: #{newNum2}"
               if newNum2.include? "_"
                 newNum2 = newNum2.gsub!("_", " ")
               end
 
               numArr2 = newNum2.split(" ")
-              puts "Going to compare #{numArr2} that was #{d} originally vs #{numArr} that was #{c} originally"
+              #puts "Going to compare #{numArr2} that was #{d} originally vs #{numArr} that was #{c} originally"
               #Compare each number now from left to right
 
               numArr.zip(numArr2).each do |first, second|
                   next unless (first.to_f <=> second.to_f) != 0
-                  puts "End result: #{first.to_f <=> second.to_f}"
+                  #puts "End result: #{first.to_f <=> second.to_f}"
                   return first.to_f <=> second.to_f
               end
             else
@@ -135,7 +135,7 @@ module LibertyBuildpack
                   d = "0."+d
                 end
                 next unless (c.to_f <=> d.to_f) != 0
-                puts "End result: #{c.to_f <=> d.to_f}"
+                #puts "End result: #{c.to_f <=> d.to_f}"
                 return c.to_f <=> d.to_f
             end
           end

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -86,14 +86,14 @@ module LibertyBuildpack
                           end
                         else
                             puts "HEREEEE"
-                            if c[0] == "0"
+                            if c[0] == "0" and c.length > 1
                               c = "0."+c
                             end
-                            if d[0] == "0"
+                            if d[0] == "0" and d.length > 1
                               d = "0."+d
                             end
                             next unless (c.to_f <=> d.to_f) != 0
-                            puts "End result: #{a.to_f <=> b.to_f}"
+                            puts "End result: #{c.to_f <=> d.to_f}"
                             return c.to_f <=> d.to_f
                         end
                       end }

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -85,6 +85,7 @@ module LibertyBuildpack
                               return first.to_f <=> second.to_f
                           end
                         else
+                            puts "HEREEEE"
                             if c[0] == "0"
                               c = "0."+c
                             end

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -50,7 +50,7 @@ module LibertyBuildpack
           version = tokenized_versions
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }
                     .max { |a, b|
-                      ver1.zip(ver2).each do |a, b|
+                      a.zip(b).each do |a, b|
                         if !/\A\d+\z/.match(a)
                           #Eliminating the letters (except ifx) for the string num in order to facilitate comparison
                           newNum = a.dup

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -60,7 +60,7 @@ module LibertyBuildpack
                           newNum = newNum.gsub!(/[a-zA-Z]/, " ")
                           newNum = newNum.gsub!("_", " ")
                           numArr = newNum.split(" ")
-                          puts "IMPRIME: #{numArr} como estaba antes: #{a}"
+                          puts "IMPRIME: #{numArr} como estaba antes: #{c}"
                           #Eliminating the letters (except ifx) for the string in b in order to facilitate comparison
                           newNum2 = d.dup
                           if newNum2.include? "ifx"
@@ -69,7 +69,7 @@ module LibertyBuildpack
                           newNum2 = newNum2.gsub!(/[a-zA-Z]/, " ")
                           newNum2 = newNum2.gsub!("_", " ")
                           numArr2 = newNum2.split(" ")
-                          puts "Going to compare #{numArr2} that was #{b} originally vs #{numArr} that was #{a} originally"
+                          puts "Going to compare #{numArr2} that was #{d} originally vs #{numArr} that was #{c} originally"
                           #Compare each number now from left to right
 
                           numArr.zip(numArr2).each do |first, second|
@@ -78,9 +78,9 @@ module LibertyBuildpack
                               return first.to_f <=> second.to_f
                           end
                         else
-                            next unless (a.to_i <=> b.to_i) != 0
+                            next unless (c.to_i <=> d.to_i) != 0
                             puts "End result: #{a.to_i <=> b.to_i}"
-                            return first.to_i <=> second.to_i
+                            return c.to_i <=> d.to_i
                         end
                       end }
 

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -51,8 +51,7 @@ module LibertyBuildpack
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }
                     .max { |a, b|
                       a.zip(b).each do |c, d|
-                        puts "Lo que ej: #{c}"
-                        if !/\A\d+\z/.match(a)
+                        if !/\A\d+\z/.match(c)
                           #Eliminating the letters (except ifx) for the string num in order to facilitate comparison
                           newNum = c.dup
                           if newNum.include? "ifx"

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -41,58 +41,55 @@ module LibertyBuildpack
           tokenized_candidate_version = safe_candidate_version candidate_version
           tokenized_versions          = versions.map { |version| create_token(version) }.compact
 
-           #this is to test out the script.
-          #if(tokenized_versions.last.to_s == "1.8.0_sr5")
+          # this is to test out the script.
+          # if(tokenized_versions.last.to_s == "1.8.0_sr5")
           #    tokenized_versions.pop
-          #end
-
+          # end
 
           version = tokenized_versions
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }
-                    .max { |a, b| version_compare(a,b)}
+                    .max { |a, b| version_compare(a, b) }
           version
         end
 
-        def version_compare(a,b)
+        def version_compare(a, b)
           a.zip(b).each do |c, d|
             if !/\A\d+\z/.match(c)
 
-              numArr = clean_version_letters(c)
+              num_arr = clean_version_letters(c)
 
-              numArr2 = clean_version_letters(d)
+              num_arr2 = clean_version_letters(d)
 
-              #Compare each number now from left to right
+              # Compare each number now from left to right
 
-              numArr.zip(numArr2).each do |first, second|
-                  next unless (first.to_f <=> second.to_f) != 0
-                  return first.to_f <=> second.to_f
+              num_arr.zip(num_arr2).each do |first, second|
+                next unless (first.to_f <=> second.to_f) != 0
+                return first.to_f <=> second.to_f
               end
             else
-                if c[0] == "0" and c.length > 1 #verify leading 0s if the number is more than one digit.
-                  c = "0."+c
-                end
-                if d[0] == "0" and d.length > 1
-                  d = "0."+d
-                end
-                next unless (c.to_f <=> d.to_f) != 0
-                return c.to_f <=> d.to_f
+              c = '0.' + c if c[0] == '0' && c.length > 1 # verify leading 0s if the number is more than one digit.
+
+              d = '0.' + d if d[0] == '0' && d.length > 1
+
+              next unless (c.to_f <=> d.to_f) != 0
+              return c.to_f <=> d.to_f
             end
           end
         end
 
-        def clean_version_letters(ver) #eliminates non numerical characters from a version number and returns an array with all the numbers from left to right
-          #Eliminating the letters (except ifx) for the string num in order to facilitate comparison
-          dupVer = ver.dup
-          if dupVer.include? "ifx"
-              dupVer = dupVer.gsub!("ifx", ".5") #converts ifx to .5 to be able to compare as a number
+        def clean_version_letters(ver) # eliminates non numerical characters from a version number and returns an array with all the numbers from left to right
+          # Eliminating the letters (except ifx) for the string num in order to facilitate comparison
+          dup_ver = ver.dup
+          if dup_ver.include? 'ifx'
+            dup_ver = dup_ver.gsub!('ifx', '.5') # converts ifx to .5 to be able to compare as a number
           end
-          dupVer = dupVer.gsub!(/[a-zA-Z]/, " ") #replaces letters with blank spaces
+          dup_ver = dup_ver.gsub!(/[a-zA-Z]/, ' ') # replaces letters with blank spaces
 
-          if dupVer.include? "_"
-            dupVer = dupVer.gsub!("_", " ") #in case there is an "_", replace with a blank space
+          if dup_ver.include? '_'
+            dup_ver = dup_ver.tr!('_', ' ') # in case there is an "_", replace with a blank space
           end
 
-          return dupVer.split(" ") #split the string into an array using the blank spaces as the splitting point
+          dup_ver.split(' ') # split the string into an array using the blank spaces as the splitting point
         end
 
         private
@@ -128,8 +125,6 @@ module LibertyBuildpack
               tokenized_candidate_version[i] == tokenized_version[i]
           end
         end
-
-
 
       end
 

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -75,11 +75,12 @@ module LibertyBuildpack
                           numArr.zip(numArr2).each do |first, second|
                               next unless (first.to_f <=> second.to_f) != 0
                               puts "End result: #{first.to_f <=> second.to_f}"
-                              break
+                              return first.to_f <=> second.to_f
                           end
                         else
                             next unless (a.to_i <=> b.to_i) != 0
                             puts "End result: #{a.to_i <=> b.to_i}"
+                            return first.to_i <=> second.to_i
                         end
                       end }
 

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -41,7 +41,7 @@ module LibertyBuildpack
           tokenized_candidate_version = safe_candidate_version candidate_version
           tokenized_versions          = versions.map { |version| create_token(version) }.compact
 
-          puts "HERE: #{tokenized_versions.class}"
+          puts "HERE: #{tokenized_versions.pop}"
 
           version = tokenized_versions
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -41,12 +41,14 @@ module LibertyBuildpack
           tokenized_candidate_version = safe_candidate_version candidate_version
           tokenized_versions          = versions.map { |version| create_token(version) }.compact
 
-          puts "HERE: #{tokenized_versions.pop}" if (tokenized_versions.pop == "1.8.0_sr5")
+          puts "HERE: #{tokenized_versions.pop}" if (tokenized_versions.last == "1.8.0_sr5")
 
           version = tokenized_versions
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }
-                    .max { |a, b| a <=> b }
+                    #.max { |a, b| a <=> b }
 
+          puts "LET'S SEE #{version}"
+          
           version
         end
 

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -43,7 +43,7 @@ module LibertyBuildpack
 
           version = tokenized_versions
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }
-                    .max { |a, b| a <=> b }
+                    .max { |a, b| a.to_i <=> b.to_i }
 
           version
         end

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -29,7 +29,7 @@ module LibertyBuildpack
       class << self
 
         # Resolves a version from a collection of versions.  The +candidate_version+ must be structured like:
-        #   * up to three numeric components, followed by an optional string component
+        #   * up to three numeric covmponents, followed by an optional string component
         #   * the final component may be a +
         # The resolution returns the maximum of the versions that match the candidate version
         #
@@ -43,7 +43,7 @@ module LibertyBuildpack
 
           version = tokenized_versions
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }
-                    .max { |a, b| a.to_i <=> b.to_i }
+                    .max { |a.to_i, b.to_i| a.to_i <=> b.to_i }
 
           version
         end

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -54,12 +54,15 @@ module LibertyBuildpack
                         if !/\A\d+\z/.match(c)
                           #Eliminating the letters (except ifx) for the string num in order to facilitate comparison
                           newNum = c.dup
-
+                          puts "TESTING: #{}"
                           if newNum.include? "ifx"
-                              newNum = newNum.to_s.gsub!("ifx", ".5")
+                              newNum = newNum.gsub!("ifx", ".5")
                           end
-                          newNum = newNum.to_s.gsub!(/[a-zA-Z]/, " ")
-                          newNum = newNum.gsub!("_", " ")
+                          newNum = newNum.gsub!(/[a-zA-Z]/, " ")
+                          if newNum.include? "_"
+                            newNum = newNum.gsub!("_", " ")
+                          end
+
                           numArr = newNum.split(" ")
                           puts "IMPRIME: #{numArr} como estaba antes: #{c}"
                           #Eliminating the letters (except ifx) for the string in b in order to facilitate comparison
@@ -68,7 +71,10 @@ module LibertyBuildpack
                               newNum2 = newNum2.gsub!("ifx", ".5")
                           end
                           newNum2 = newNum2.gsub!(/[a-zA-Z]/, " ")
-                          newNum2 = newNum2.gsub!("_", " ")
+                          if newNum2.include? "_"
+                            newNum2 = newNum2.gsub!("_", " ")
+                          end
+
                           numArr2 = newNum2.split(" ")
                           puts "Going to compare #{numArr2} that was #{d} originally vs #{numArr} that was #{c} originally"
                           #Compare each number now from left to right

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -41,7 +41,7 @@ module LibertyBuildpack
           tokenized_candidate_version = safe_candidate_version candidate_version
           tokenized_versions          = versions.map { |version| create_token(version) }.compact
 
-          puts "HERE: #{tokenized_versions}"
+          puts "HERE: #{tokenized_versions.class}"
 
           version = tokenized_versions
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -41,11 +41,11 @@ module LibertyBuildpack
           tokenized_candidate_version = safe_candidate_version candidate_version
           tokenized_versions          = versions.map { |version| create_token(version) }.compact
 
+          puts "HERE: #{tokenized_versions}"
+
           version = tokenized_versions
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }
                     .max { |a, b| a <=> b }
-
-          puts "HERE: #{version}"
 
           version
         end

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -54,11 +54,12 @@ module LibertyBuildpack
                         if !/\A\d+\z/.match(c)
                           #Eliminating the letters (except ifx) for the string num in order to facilitate comparison
                           newNum = c.dup
-                          puts "TESTING: #{newNum}"
                           if newNum.include? "ifx"
                               newNum = newNum.gsub!("ifx", ".5")
                           end
                           newNum = newNum.gsub!(/[a-zA-Z]/, " ")
+                          puts "TESTING: #{newNum}"
+                          
                           if newNum.include? "_"
                             newNum = newNum.gsub!("_", " ")
                           end
@@ -67,11 +68,11 @@ module LibertyBuildpack
                           puts "IMPRIME: #{numArr} como estaba antes: #{c}"
                           #Eliminating the letters (except ifx) for the string in b in order to facilitate comparison
                           newNum2 = d.dup
-                          puts "TESTING: #{newNum2}"
                           if newNum2.include? "ifx"
                               newNum2 = newNum2.gsub!("ifx", ".5")
                           end
                           newNum2 = newNum2.gsub!(/[a-zA-Z]/, " ")
+                          puts "TESTING: #{newNum2}"
                           if newNum2.include? "_"
                             newNum2 = newNum2.gsub!("_", " ")
                           end
@@ -86,7 +87,6 @@ module LibertyBuildpack
                               return first.to_f <=> second.to_f
                           end
                         else
-                            puts "HEREEEE"
                             if c[0] == "0" and c.length > 1
                               c = "0."+c
                             end

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -85,7 +85,13 @@ module LibertyBuildpack
                               return first.to_f <=> second.to_f
                           end
                         else
-                            next unless (c.to_i <=> d.to_i) != 0
+                            if c[0] == "0"
+                              c = "0."+c
+                            end
+                            if d[0] == "0"
+                              d = "0."+d
+                            end
+                            next unless (c.to_f <=> d.to_f) != 0
                             puts "End result: #{a.to_f <=> b.to_f}"
                             return c.to_f <=> d.to_f
                         end

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -51,7 +51,7 @@ module LibertyBuildpack
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }
                     .max { |a, b|
                       a.zip(b).each do |c, d|
-                        if !/\A\d+\z/.match(c)
+                        if !/\A\d+\z/.match(c.to_s)
                           #Eliminating the letters (except ifx) for the string num in order to facilitate comparison
                           newNum = c.dup
                           if newNum.include? "ifx"

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -86,8 +86,8 @@ module LibertyBuildpack
                           end
                         else
                             next unless (c.to_i <=> d.to_i) != 0
-                            puts "End result: #{a.to_i <=> b.to_i}"
-                            return c.to_i <=> d.to_i
+                            puts "End result: #{a.to_f <=> b.to_f}"
+                            return c.to_f <=> d.to_f
                         end
                       end }
 

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -45,9 +45,10 @@ module LibertyBuildpack
 
           version = tokenized_versions
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }
-                    #.max { |a, b| a <=> b }
+                    .max { |a, b| a <=> b }
 
-          #puts "LET'S SEE #{version}"
+          puts "LET'S SEE #{tokenized_versions
+                    .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }}"
 
           version
         end

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -41,7 +41,7 @@ module LibertyBuildpack
           tokenized_candidate_version = safe_candidate_version candidate_version
           tokenized_versions          = versions.map { |version| create_token(version) }.compact
 
-          puts "HERE: #{tokenized_versions.pop}" if (tokenized_versions.last == "1.8.0_sr5")
+          puts "HERE: #{tokenized_versions.last}" 
 
           version = tokenized_versions
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -41,11 +41,11 @@ module LibertyBuildpack
           tokenized_candidate_version = safe_candidate_version candidate_version
           tokenized_versions          = versions.map { |version| create_token(version) }.compact
 
-          if(tokenized_versions.last == "1.8.0_sr5")
+          if(tokenized_versions.last.to_s == "1.8.0_sr5")
               print "Before: #{tokenized_versions}"
               puts "HERE: #{tokenized_versions.pop}"
               print "After: #{tokenized_versions}"
-          end 
+          end
 
           version = tokenized_versions
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -41,7 +41,11 @@ module LibertyBuildpack
           tokenized_candidate_version = safe_candidate_version candidate_version
           tokenized_versions          = versions.map { |version| create_token(version) }.compact
 
-          puts "HERE: #{tokenized_versions.last}" 
+          if(tokenized_versions.last == "1.8.0_sr5")
+              print "Before: #{tokenized_versions}"
+              puts "HERE: #{tokenized_versions.pop}"
+              print "After: #{tokenized_versions}"
+          end 
 
           version = tokenized_versions
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -52,6 +52,10 @@ module LibertyBuildpack
           version
         end
 
+        # Compares two distinct versions using only the numbers
+        # @param [String] a is one of the versions to compare
+        # @param [String] b is the other version to compare
+        # @return [Integer] 1, if a is greater than b; 0 if they are the same value; and -1 if a is less than b
         def version_compare(a, b)
           a.zip(b).each do |c, d|
             if !/\A\d+\z/.match(c)
@@ -74,10 +78,15 @@ module LibertyBuildpack
               next unless (c.to_f <=> d.to_f) != 0
               return c.to_f <=> d.to_f
             end
+
+            return 0 # if it reaches this point, it means that both versions are the same one
           end
         end
 
-        def clean_version_letters(ver) # eliminates non numerical characters from a version number and returns an array with all the numbers from left to right
+        # eliminates non numerical characters from a version number and returns an array with all the numbers from left to right
+        # @param [String] ver is the version number to clean up and replace the letters with spaces and numbers in order to have a number version format
+        # @return [Array<String>] the version number in an array where each element was separated by a '.'
+        def clean_version_letters(ver)
           # Eliminating the letters (except ifx) for the string num in order to facilitate comparison
           dup_ver = ver.dup
           if dup_ver.include? 'ifx'

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -47,7 +47,9 @@ module LibertyBuildpack
               #print "After: #{tokenized_versions}"
           end
 
-          version = tokenized_versions
+
+
+          puts "This is the result: #{version = tokenized_versions
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }
                     .max { |a, b|
                       a.zip(b).each do |c, d|
@@ -82,9 +84,7 @@ module LibertyBuildpack
                             puts "End result: #{a.to_i <=> b.to_i}"
                             return first.to_i <=> second.to_i
                         end
-                      end }
-
-          puts "This is the result: #{version}"
+                      end }}"
 
           version
         end

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -43,17 +43,17 @@ module LibertyBuildpack
 
           if(tokenized_versions.last.to_s == "1.8.0_sr5")
               #print "Before: #{tokenized_versions}"
-              puts "HERE: #{tokenized_versions.pop.last}"
+              puts "HERE: #{tokenized_versions.pop}"
               #print "After: #{tokenized_versions}"
           end
 
           version = tokenized_versions
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }
                     .max { |a, b|
-                      a.zip(b).each do |a, b|
+                      a.zip(b).each do |c, d|
                         if !/\A\d+\z/.match(a)
                           #Eliminating the letters (except ifx) for the string num in order to facilitate comparison
-                          newNum = a.dup
+                          newNum = c.dup
                           if newNum.include? "ifx"
                               newNum = newNum.gsub!("ifx", ".5")
                           end
@@ -62,7 +62,7 @@ module LibertyBuildpack
                           numArr = newNum.split(" ")
                           puts "IMPRIME: #{numArr} como estaba antes: #{a}"
                           #Eliminating the letters (except ifx) for the string in b in order to facilitate comparison
-                          newNum2 = b.dup
+                          newNum2 = d.dup
                           if newNum2.include? "ifx"
                               newNum2 = newNum2.gsub!("ifx", ".5")
                           end

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -41,19 +41,15 @@ module LibertyBuildpack
           tokenized_candidate_version = safe_candidate_version candidate_version
           tokenized_versions          = versions.map { |version| create_token(version) }.compact
 
-          if(tokenized_versions.last.to_s == "1.8.0_sr5")
-              #print "Before: #{tokenized_versions}"
-              #puts "HERE: #{tokenized_versions.pop}"
-              tokenized_versions.pop
-              #print "After: #{tokenized_versions}"
-          end
+           #this is to test out the script.
+          #if(tokenized_versions.last.to_s == "1.8.0_sr5")
+          #    tokenized_versions.pop
+          #end
+
 
           version = tokenized_versions
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }
-                    .max { |a, b| custom_compare(a,b)}
-
-          #puts "This is the result: #{version}"
-
+                    .max { |a, b| version_compare(a,b)}
           version
         end
 
@@ -91,23 +87,23 @@ module LibertyBuildpack
           end
         end
 
-        def custom_compare(a,b)
+        def version_compare(a,b)
           a.zip(b).each do |c, d|
             if !/\A\d+\z/.match(c)
               #Eliminating the letters (except ifx) for the string num in order to facilitate comparison
               newNum = c.dup
               if newNum.include? "ifx"
-                  newNum = newNum.gsub!("ifx", ".5")
+                  newNum = newNum.gsub!("ifx", ".5") #converts ifx to .5 to be able to compare as a number
               end
-              newNum = newNum.gsub!(/[a-zA-Z]/, " ")
+              newNum = newNum.gsub!(/[a-zA-Z]/, " ") #replaces letters with blank spaces
               #puts "TESTING: #{newNum}"
 
               if newNum.include? "_"
-                newNum = newNum.gsub!("_", " ")
+                newNum = newNum.gsub!("_", " ") #in case there is an "_", replace with a blank space
               end
 
-              numArr = newNum.split(" ")
-              #puts "IMPRIME: #{numArr} como estaba antes: #{c}"
+              numArr = newNum.split(" ") #split the string into an array using the blank spaces as the splitting point
+
               #Eliminating the letters (except ifx) for the string in b in order to facilitate comparison
               newNum2 = d.dup
               if newNum2.include? "ifx"
@@ -120,23 +116,21 @@ module LibertyBuildpack
               end
 
               numArr2 = newNum2.split(" ")
-              #puts "Going to compare #{numArr2} that was #{d} originally vs #{numArr} that was #{c} originally"
+
               #Compare each number now from left to right
 
               numArr.zip(numArr2).each do |first, second|
                   next unless (first.to_f <=> second.to_f) != 0
-                  #puts "End result: #{first.to_f <=> second.to_f}"
                   return first.to_f <=> second.to_f
               end
             else
-                if c[0] == "0" and c.length > 1
+                if c[0] == "0" and c.length > 1 #verify leading 0s if the number is more than one digit.
                   c = "0."+c
                 end
                 if d[0] == "0" and d.length > 1
                   d = "0."+d
                 end
                 next unless (c.to_f <=> d.to_f) != 0
-                #puts "End result: #{c.to_f <=> d.to_f}"
                 return c.to_f <=> d.to_f
             end
           end

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -84,6 +84,8 @@ module LibertyBuildpack
                         end
                       end }
 
+          puts "This is the result: #{version}"
+
           version
         end
 

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -41,7 +41,7 @@ module LibertyBuildpack
           tokenized_candidate_version = safe_candidate_version candidate_version
           tokenized_versions          = versions.map { |version| create_token(version) }.compact
 
-          puts "HERE: #{tokenized_versions.pop}" if (tokenized_versions.pop == "1.8.0.sr5")
+          puts "HERE: #{tokenized_versions.pop}" if (tokenized_versions.pop == "1.8.0_sr5")
 
           version = tokenized_versions
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -51,7 +51,7 @@ module LibertyBuildpack
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }
                     .max { |a, b|
                       a.zip(b).each do |c, d|
-                        puts "Lo que ej: #{a}"
+                        puts "Lo que ej: #{c}"
                         if !/\A\d+\z/.match(a)
                           #Eliminating the letters (except ifx) for the string num in order to facilitate comparison
                           newNum = c.dup

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -54,11 +54,11 @@ module LibertyBuildpack
                         if !/\A\d+\z/.match(c)
                           #Eliminating the letters (except ifx) for the string num in order to facilitate comparison
                           newNum = c.dup
-                          puts "TESTING: #{newNum}"
+
                           if newNum.include? "ifx"
-                              newNum = newNum.gsub!("ifx", ".5")
+                              newNum = newNum.to_s.gsub!("ifx", ".5")
                           end
-                          newNum = newNum.gsub!(/[a-zA-Z]/, " ")
+                          newNum = newNum.to_s.gsub!(/[a-zA-Z]/, " ")
                           newNum = newNum.gsub!("_", " ")
                           numArr = newNum.split(" ")
                           puts "IMPRIME: #{numArr} como estaba antes: #{c}"

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -47,12 +47,11 @@ module LibertyBuildpack
               #print "After: #{tokenized_versions}"
           end
 
-
-
-          puts "This is the result: #{version = tokenized_versions
+          version = tokenized_versions
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }
                     .max { |a, b|
                       a.zip(b).each do |c, d|
+                        puts "Lo que ej: #{a}"
                         if !/\A\d+\z/.match(a)
                           #Eliminating the letters (except ifx) for the string num in order to facilitate comparison
                           newNum = c.dup
@@ -84,7 +83,9 @@ module LibertyBuildpack
                             puts "End result: #{a.to_i <=> b.to_i}"
                             return first.to_i <=> second.to_i
                         end
-                      end }}"
+                      end }
+
+          puts "This is the result: #{version}"
 
           version
         end

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -54,7 +54,7 @@ module LibertyBuildpack
                         if !/\A\d+\z/.match(c)
                           #Eliminating the letters (except ifx) for the string num in order to facilitate comparison
                           newNum = c.dup
-                          puts "TESTING: #{}"
+                          puts "TESTING: #{newNum}"
                           if newNum.include? "ifx"
                               newNum = newNum.gsub!("ifx", ".5")
                           end
@@ -67,6 +67,7 @@ module LibertyBuildpack
                           puts "IMPRIME: #{numArr} como estaba antes: #{c}"
                           #Eliminating the letters (except ifx) for the string in b in order to facilitate comparison
                           newNum2 = d.dup
+                          puts "TESTING: #{newNum2}"
                           if newNum2.include? "ifx"
                               newNum2 = newNum2.gsub!("ifx", ".5")
                           end

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -59,7 +59,7 @@ module LibertyBuildpack
                           end
                           newNum = newNum.gsub!(/[a-zA-Z]/, " ")
                           puts "TESTING: #{newNum}"
-                          
+
                           if newNum.include? "_"
                             newNum = newNum.gsub!("_", " ")
                           end
@@ -85,6 +85,7 @@ module LibertyBuildpack
                               next unless (first.to_f <=> second.to_f) != 0
                               puts "End result: #{first.to_f <=> second.to_f}"
                               return first.to_f <=> second.to_f
+                              break
                           end
                         else
                             if c[0] == "0" and c.length > 1
@@ -96,6 +97,7 @@ module LibertyBuildpack
                             next unless (c.to_f <=> d.to_f) != 0
                             puts "End result: #{c.to_f <=> d.to_f}"
                             return c.to_f <=> d.to_f
+                            break
                         end
                       end }
 

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -53,6 +53,48 @@ module LibertyBuildpack
           version
         end
 
+        def version_compare(a,b)
+          a.zip(b).each do |c, d|
+            if !/\A\d+\z/.match(c)
+
+              numArr = clean_version_letters(c)
+
+              numArr2 = clean_version_letters(d)
+
+              #Compare each number now from left to right
+
+              numArr.zip(numArr2).each do |first, second|
+                  next unless (first.to_f <=> second.to_f) != 0
+                  return first.to_f <=> second.to_f
+              end
+            else
+                if c[0] == "0" and c.length > 1 #verify leading 0s if the number is more than one digit.
+                  c = "0."+c
+                end
+                if d[0] == "0" and d.length > 1
+                  d = "0."+d
+                end
+                next unless (c.to_f <=> d.to_f) != 0
+                return c.to_f <=> d.to_f
+            end
+          end
+        end
+
+        def clean_version_letters(ver) #eliminates non numerical characters from a version number and returns an array with all the numbers from left to right
+          #Eliminating the letters (except ifx) for the string num in order to facilitate comparison
+          dupVer = ver.dup
+          if dupVer.include? "ifx"
+              dupVer = dupVer.gsub!("ifx", ".5") #converts ifx to .5 to be able to compare as a number
+          end
+          dupVer = dupVer.gsub!(/[a-zA-Z]/, " ") #replaces letters with blank spaces
+
+          if dupVer.include? "_"
+            dupVer = dupVer.gsub!("_", " ") #in case there is an "_", replace with a blank space
+          end
+
+          return dupVer.split(" ") #split the string into an array using the blank spaces as the splitting point
+        end
+
         private
 
         TOKENIZED_WILDCARD = LibertyBuildpack::Util::TokenizedVersion.new('+').freeze
@@ -87,54 +129,7 @@ module LibertyBuildpack
           end
         end
 
-        def version_compare(a,b)
-          a.zip(b).each do |c, d|
-            if !/\A\d+\z/.match(c)
-              #Eliminating the letters (except ifx) for the string num in order to facilitate comparison
-              newNum = c.dup
-              if newNum.include? "ifx"
-                  newNum = newNum.gsub!("ifx", ".5") #converts ifx to .5 to be able to compare as a number
-              end
-              newNum = newNum.gsub!(/[a-zA-Z]/, " ") #replaces letters with blank spaces
-              #puts "TESTING: #{newNum}"
 
-              if newNum.include? "_"
-                newNum = newNum.gsub!("_", " ") #in case there is an "_", replace with a blank space
-              end
-
-              numArr = newNum.split(" ") #split the string into an array using the blank spaces as the splitting point
-
-              #Eliminating the letters (except ifx) for the string in b in order to facilitate comparison
-              newNum2 = d.dup
-              if newNum2.include? "ifx"
-                  newNum2 = newNum2.gsub!("ifx", ".5")
-              end
-              newNum2 = newNum2.gsub!(/[a-zA-Z]/, " ")
-              #puts "TESTING: #{newNum2}"
-              if newNum2.include? "_"
-                newNum2 = newNum2.gsub!("_", " ")
-              end
-
-              numArr2 = newNum2.split(" ")
-
-              #Compare each number now from left to right
-
-              numArr.zip(numArr2).each do |first, second|
-                  next unless (first.to_f <=> second.to_f) != 0
-                  return first.to_f <=> second.to_f
-              end
-            else
-                if c[0] == "0" and c.length > 1 #verify leading 0s if the number is more than one digit.
-                  c = "0."+c
-                end
-                if d[0] == "0" and d.length > 1
-                  d = "0."+d
-                end
-                next unless (c.to_f <=> d.to_f) != 0
-                return c.to_f <=> d.to_f
-            end
-          end
-        end
 
       end
 

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -43,7 +43,8 @@ module LibertyBuildpack
 
           if(tokenized_versions.last.to_s == "1.8.0_sr5")
               #print "Before: #{tokenized_versions}"
-              puts "HERE: #{tokenized_versions.pop}"
+              #puts "HERE: #{tokenized_versions.pop}"
+              tokenized_versions.pop
               #print "After: #{tokenized_versions}"
           end
 
@@ -51,7 +52,7 @@ module LibertyBuildpack
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }
                     .max { |a, b| custom_compare(a,b)}
 
-          puts "This is the result: #{version}"
+          #puts "This is the result: #{version}"
 
           version
         end

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -49,57 +49,7 @@ module LibertyBuildpack
 
           version = tokenized_versions
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }
-                    .max { |a, b|
-                      a.zip(b).each do |c, d|
-                        if !/\A\d+\z/.match(c)
-                          #Eliminating the letters (except ifx) for the string num in order to facilitate comparison
-                          newNum = c.dup
-                          if newNum.include? "ifx"
-                              newNum = newNum.gsub!("ifx", ".5")
-                          end
-                          newNum = newNum.gsub!(/[a-zA-Z]/, " ")
-                          puts "TESTING: #{newNum}"
-
-                          if newNum.include? "_"
-                            newNum = newNum.gsub!("_", " ")
-                          end
-
-                          numArr = newNum.split(" ")
-                          puts "IMPRIME: #{numArr} como estaba antes: #{c}"
-                          #Eliminating the letters (except ifx) for the string in b in order to facilitate comparison
-                          newNum2 = d.dup
-                          if newNum2.include? "ifx"
-                              newNum2 = newNum2.gsub!("ifx", ".5")
-                          end
-                          newNum2 = newNum2.gsub!(/[a-zA-Z]/, " ")
-                          puts "TESTING: #{newNum2}"
-                          if newNum2.include? "_"
-                            newNum2 = newNum2.gsub!("_", " ")
-                          end
-
-                          numArr2 = newNum2.split(" ")
-                          puts "Going to compare #{numArr2} that was #{d} originally vs #{numArr} that was #{c} originally"
-                          #Compare each number now from left to right
-
-                          numArr.zip(numArr2).each do |first, second|
-                              next unless (first.to_f <=> second.to_f) != 0
-                              puts "End result: #{first.to_f <=> second.to_f}"
-                              return first.to_f <=> second.to_f
-                              break
-                          end
-                        else
-                            if c[0] == "0" and c.length > 1
-                              c = "0."+c
-                            end
-                            if d[0] == "0" and d.length > 1
-                              d = "0."+d
-                            end
-                            next unless (c.to_f <=> d.to_f) != 0
-                            puts "End result: #{c.to_f <=> d.to_f}"
-                            return c.to_f <=> d.to_f
-                            break
-                        end
-                      end }
+                    .max { |a, b| custom_compare(a,b)}
 
           puts "This is the result: #{version}"
 
@@ -137,6 +87,57 @@ module LibertyBuildpack
             tokenized_candidate_version[i].nil? ||
               tokenized_candidate_version[i] == LibertyBuildpack::Util::TokenizedVersion::WILDCARD ||
               tokenized_candidate_version[i] == tokenized_version[i]
+          end
+        end
+
+        def custom_compare(a,b)
+          a.zip(b).each do |c, d|
+            if !/\A\d+\z/.match(c)
+              #Eliminating the letters (except ifx) for the string num in order to facilitate comparison
+              newNum = c.dup
+              if newNum.include? "ifx"
+                  newNum = newNum.gsub!("ifx", ".5")
+              end
+              newNum = newNum.gsub!(/[a-zA-Z]/, " ")
+              puts "TESTING: #{newNum}"
+
+              if newNum.include? "_"
+                newNum = newNum.gsub!("_", " ")
+              end
+
+              numArr = newNum.split(" ")
+              #puts "IMPRIME: #{numArr} como estaba antes: #{c}"
+              #Eliminating the letters (except ifx) for the string in b in order to facilitate comparison
+              newNum2 = d.dup
+              if newNum2.include? "ifx"
+                  newNum2 = newNum2.gsub!("ifx", ".5")
+              end
+              newNum2 = newNum2.gsub!(/[a-zA-Z]/, " ")
+              puts "TESTING: #{newNum2}"
+              if newNum2.include? "_"
+                newNum2 = newNum2.gsub!("_", " ")
+              end
+
+              numArr2 = newNum2.split(" ")
+              puts "Going to compare #{numArr2} that was #{d} originally vs #{numArr} that was #{c} originally"
+              #Compare each number now from left to right
+
+              numArr.zip(numArr2).each do |first, second|
+                  next unless (first.to_f <=> second.to_f) != 0
+                  puts "End result: #{first.to_f <=> second.to_f}"
+                  return first.to_f <=> second.to_f
+              end
+            else
+                if c[0] == "0" and c.length > 1
+                  c = "0."+c
+                end
+                if d[0] == "0" and d.length > 1
+                  d = "0."+d
+                end
+                next unless (c.to_f <=> d.to_f) != 0
+                puts "End result: #{c.to_f <=> d.to_f}"
+                return c.to_f <=> d.to_f
+            end
           end
         end
 

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -42,9 +42,9 @@ module LibertyBuildpack
           tokenized_versions          = versions.map { |version| create_token(version) }.compact
 
           if(tokenized_versions.last.to_s == "1.8.0_sr5")
-              print "Before: #{tokenized_versions}"
-              puts "HERE: #{tokenized_versions.pop}"
-              print "After: #{tokenized_versions}"
+              #print "Before: #{tokenized_versions}"
+              puts "HERE: #{tokenized_versions.pop.last}"
+              #print "After: #{tokenized_versions}"
           end
 
           version = tokenized_versions

--- a/lib/liberty_buildpack/repository/version_resolver.rb
+++ b/lib/liberty_buildpack/repository/version_resolver.rb
@@ -29,7 +29,7 @@ module LibertyBuildpack
       class << self
 
         # Resolves a version from a collection of versions.  The +candidate_version+ must be structured like:
-        #   * up to three numeric covmponents, followed by an optional string component
+        #   * up to three numeric components, followed by an optional string component
         #   * the final component may be a +
         # The resolution returns the maximum of the versions that match the candidate version
         #
@@ -43,7 +43,9 @@ module LibertyBuildpack
 
           version = tokenized_versions
                     .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }
-                    .max { |a.to_i, b.to_i| a.to_i <=> b.to_i }
+                    .max { |a, b| a <=> b }
+
+          puts "HERE: #{version}"
 
           version
         end

--- a/spec/liberty_buildpack/repository/version_resolver_spec.rb
+++ b/spec/liberty_buildpack/repository/version_resolver_spec.rb
@@ -68,7 +68,7 @@ describe LibertyBuildpack::Repository::VersionResolver do
   end
 
   it 'eliminates the letters in version numbers' do
-    expect(described_class.clean_version_letters('0_sr4fp11')).to eq(['0','4','11'])
+    expect(described_class.clean_version_letters('0_sr4fp11')).to eq(%w(0 4 11))
   end
 
   def tokenized_version(s)

--- a/spec/liberty_buildpack/repository/version_resolver_spec.rb
+++ b/spec/liberty_buildpack/repository/version_resolver_spec.rb
@@ -22,7 +22,7 @@ require 'liberty_buildpack/util/tokenized_version'
 describe LibertyBuildpack::Repository::VersionResolver do
   include_context 'logging_helper'
 
-  let(:versions) { %w(1.6.0_26 1.6.0_27 1.6.1_14 1.7.0_19 1.7.0_21 1.8.0_M-7 1.8.0_05 2.0.0 2.0.0a) }
+  let(:versions) { %w(1.6.0_26 1.6.0_27 1.6.1_14 1.7.0_sr4fp7 1.7.0_sr4fp11 1.8.0_M-7 1.8.0_05 2.0.0 2.0.0a) }
 
   it 'resolves the default version if no candidate is supplied' do
     expect(described_class.resolve(nil, versions)).to eq(tokenized_version('2.0.0'))
@@ -43,6 +43,7 @@ describe LibertyBuildpack::Repository::VersionResolver do
   it 'resolves a wildcard qualifier' do
     expect(described_class.resolve(tokenized_version('1.6.0_+'), versions)).to eq(tokenized_version('1.6.0_27'))
     expect(described_class.resolve(tokenized_version('1.8.0_+'), versions)).to eq(tokenized_version('1.8.0_05'))
+    expect(described_class.resolve(tokenized_version('1.7.0_+'), versions)).to eq(tokenized_version('1.7.0_sr4fp11'))
   end
 
   it 'resolves a non-wildcard version' do
@@ -60,6 +61,14 @@ describe LibertyBuildpack::Repository::VersionResolver do
 
   it 'ignores illegal versions' do
     expect(described_class.resolve(tokenized_version('2.0.+'), versions)).to eq(tokenized_version('2.0.0'))
+  end
+
+  it 'returns the most recent version' do
+    expect(described_class.version_compare(tokenized_version('1.7.0_sr4fp7'), tokenized_version('1.7.0_sr4fp11'))).to eq(-1)
+  end
+
+  it 'eliminates the letters in version numbers' do
+    expect(described_class.clean_version_letters('0_sr4fp11')).to eq(['0','4','11'])
   end
 
   def tokenized_version(s)

--- a/spec/liberty_buildpack/repository/version_resolver_spec.rb
+++ b/spec/liberty_buildpack/repository/version_resolver_spec.rb
@@ -71,6 +71,14 @@ describe LibertyBuildpack::Repository::VersionResolver do
     expect(described_class.clean_version_letters('0_sr4fp11')).to eq(%w(0 4 11))
   end
 
+  it 'ignores leading 0s when comparing' do
+    expect(described_class.version_compare(tokenized_version('19.0.01'), tokenized_version('19.0.1'))).to eq(-1)
+  end
+
+  it 'replaces the suffix "ifx" with a ".5" for easier comparison' do
+    expect(described_class.clean_version_letters('0_sr4fp11ifx')).to eq(%w(0 4 11.5))
+  end
+
   def tokenized_version(s)
     LibertyBuildpack::Util::TokenizedVersion.new(s)
   end


### PR DESCRIPTION
Now it is supposed to pick the correct JRE Version. You can see the methods "version_compare" and "clean_version_letters" for more info. Both passed the unit tests and the other tests were modified accordingly and passed as well.