### PR TITLE
Changed service detection for Dynatrace AppMon integration

### DIFF
--- a/spec/liberty_buildpack/framework/dynatrace_appmon_agent_spec.rb
+++ b/spec/liberty_buildpack/framework/dynatrace_appmon_agent_spec.rb
@@ -97,6 +97,15 @@ module LibertyBuildpack::Framework
           expect { detected }.to raise_error(RuntimeError)
         end
 
+        it 'should be detected as there is only one valid service',
+           vcap_services_context: { def_type => [{ 'name' => 'dynatrace', 'label' => def_label, 'tags' => def_tags,
+                                                   'credentials' => def_credentials }],
+                                    'servicetype2' => [{ 'name' => 'dynatrace', 'label' => def_label, 'tags' => def_tags,
+                                                         'credentials' => { 'key' => 'value' } }] } do
+
+          expect(detected).to eq(detect_string)
+        end
+
         it 'should be detected when the tag includes dynatrace substring',
            vcap_services_context: { def_type => [{ 'name' => def_name, 'label' => def_label, 'tags' => ['dynatracetag'],
                                                    'credentials' => def_credentials }] } do


### PR DESCRIPTION
The Dynatrace AppMon integration raises an error in case there are more
than one service containing "dynatrace". This might not be supported for
the AppMon integration, but is for the OneAgent integration.

The AppMon integation now only fails if multiple valid services which
are not for the OneAgent integation are bound to the application.