### PR TITLE
Add support for CA APM Agent

### DIFF
--- a/config/caapmagent.yml
+++ b/config/caapmagent.yml
@@ -1,0 +1,20 @@
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2018 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Service configuration
+---
+version: 10.+
+repository_root: https://ca.bintray.com/websphere
+default_agent_name: $(ruby -e "require 'json' ; puts JSON.parse(ENV['VCAP_APPLICATION'])['application_name']")

--- a/config/components.yml
+++ b/config/components.yml
@@ -34,3 +34,4 @@ frameworks:
   - "LibertyBuildpack::Framework::DynamicPULSEAgent"
   - "LibertyBuildpack::Framework::ContainerCertificateTrustStore"
   - "LibertyBuildpack::Framework::ContrastSecurityAgent"
+  - "LibertyBuildpack::Framework::CAAPMAgent"

--- a/docs/framework-caapm_agent.md
+++ b/docs/framework-caapm_agent.md
@@ -1,0 +1,37 @@
+# CA APM Agent Framework
+The CA APM Agent Framework causes an application to be automatically configured to work with a bound [CA APM Service][].
+
+<table>
+  <tr>
+    <td><strong>Detection Criterion</strong></td><td>Existence of a single bound CA APM service. The existence of an CA APM service defined by the <a href="http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES"><code>VCAP_SERVICES</code></a> payload containing a service name, label or tag with <code>introscope</code> as a substring.
+</td>
+  </tr>
+  <tr>
+    <td><strong>Tags</strong></td><td><tt>introscope-agent=<version>&lt;version&gt;</tt></td>
+  </tr>
+</table>
+
+Tags are printed to standard output by the buildpack detect script.
+
+## User-Provided Service
+When binding CA APM using a user-provided service, it must have name or tag with `introscope` in it. The credential payload can contain the following entries:
+
+| Name | Description
+| ---- | -----------
+| agent_name | (Optional) The The name that should be given to this instance of the Introscope agent.
+| agent_manager_credential | (Optional) The agent manager credential that is used to connect to the Enterprise Manager Server for SaaS.
+| agent_manager_url | The url of the Enterprise Manager server.
+
+
+## Configuration
+For general information on configuring the buildpack, including how to specify configuration values through environment variables, refer to [Configuration and Extension][].
+The framework can be configured by modifying the [config] file in the buildpack fork. 
+
+| Name | Description
+| ---- | -----------
+| repository_root | The URL of the CA APM repository index, which can be found in the [config] file.
+| version | The version of CA APM Agent to use. 
+
+[config]: ../config/caapmagent.yml
+[CA APM Service]: https://www.ca.com/us/products/ca-application-performance-management.html
+[Configuration and Extension]: ../README.md#configuration-and-extension

--- a/lib/liberty_buildpack/container/container_utils.rb
+++ b/lib/liberty_buildpack/container/container_utils.rb
@@ -91,6 +91,19 @@ module LibertyBuildpack::Container
       end
     end
 
+    # Unpacks the given tar file to the specified directory.
+    #
+    # @param [String] file - the tar file to unpack.
+    # @param [String] dir - the directory to unpack the tar contents into.
+    # @return [void]
+    def self.untar(file, dir)
+      file = File.expand_path(file)
+      FileUtils.mkdir_p dir
+      Dir.chdir(dir) do
+        system "tar xf \"#{file}\""
+      end
+    end
+
     # Overlay JVM files. Move base_dir/resources/.java-overlay/.java files to app_dir/.
     #
     # @param [String] base_dir the base directory that contains Java files to overlay.

--- a/lib/liberty_buildpack/framework/ca_apm_agent.rb
+++ b/lib/liberty_buildpack/framework/ca_apm_agent.rb
@@ -1,0 +1,181 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2018 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'fileutils'
+require 'liberty_buildpack/diagnostics/logger_factory'
+require 'liberty_buildpack/framework'
+require 'liberty_buildpack/repository/configured_item'
+require 'liberty_buildpack/util/download'
+require 'liberty_buildpack/container/common_paths'
+require 'liberty_buildpack/services/vcap_services'
+
+module LibertyBuildpack::Framework
+
+  # The CAAPMAgent class that provides CA APM Agent resource as a framework to applications
+  class CAAPMAgent
+
+    # The name of the directory which contains the CA APM agent.
+    CA_APM_HOME_DIR = '.ca_apm'.freeze
+
+    # Creates an instance of the CAAPMAgent class and takes as an argument the context hash.
+    # @param [Hash] context the context that is provided to the instance, defaults to empty.
+    # @option context [String] :app_dir the directory that the application exists in.
+    # @option context [Hash] :configuration the properties provided by the user.
+    # @option context [CommonPaths] :common_paths the set of paths common across components that components should reference.
+    # @option context [Hash] :vcap_application the application information provided by cf.
+    # @option context [Hash] :vcap_services the services bound to the application provided by cf.
+    # @option context [Array<String>] :java_opts an array in which the java options can be added.
+    def initialize(context = {})
+      @logger = LibertyBuildpack::Diagnostics::LoggerFactory.get_logger
+      @app_dir = context[:app_dir]
+      @configuration = context[:configuration]
+      @common_paths = context[:common_paths] || LibertyBuildpack::Container::CommonPaths.new
+      @vcap_application = context[:vcap_application]
+      @vcap_services = context[:vcap_services]
+      @services = @vcap_services ? LibertyBuildpack::Services::VcapServices.new(@vcap_services) : LibertyBuildpack::Services::VcapServices.new({})
+      @java_opts = context[:java_opts]
+    end
+
+    # Determines if the application's VCAP environment and the configured CA APM configuration
+    # is available for the CA APM framework to provide a configured CA APM agent. Valid
+    # detection is based on VCAP_SERVICES, VCAP_APPLICATION, and the repository root index.yml
+    # defined in the CA APM configuration file.
+    #
+    # @return [String] the detected versioned ID if the environment and config are valid, nil otherwise.
+    def detect
+      app_has_name? && service_exists? ? process_config : nil
+    end
+
+    # Create the ca_apm directory and its contents for the app droplet.
+    def compile
+      if @app_dir.nil?
+        raise 'app directory must be provided'
+      elsif @version.nil? || @uri.nil?
+        raise "Version #{@version}, uri #{@uri} is not available, detect needs to be invoked"
+      end
+
+      ca_apm_home = File.join(@app_dir, CA_APM_HOME_DIR)
+      FileUtils.mkdir_p(ca_apm_home)
+      download_and_install_agent(ca_apm_home)
+    end
+
+    # Appends the CA APM agent to the java options and specified additional properties for the agent.
+    def release
+      app_dir = @common_paths.relative_location
+      ca_apm_home_dir = File.join(app_dir, CA_APM_HOME_DIR)
+      ca_apm_agent = File.join(ca_apm_home_dir, 'wily/AgentNoRedefNoRetrans.jar')
+
+      @java_opts << "-javaagent:#{ca_apm_agent}"
+      @java_opts << '-Dorg.osgi.framework.bootdelegation=com.wily.*'
+      @java_opts << "-Dcom.wily.introscope.agentProfile=#{ca_apm_home_dir}/wily/core/config/IntroscopeAgent.NoRedef.profile"
+      credentials = @services.find_service(FILTER)['credentials']
+
+      agent_host_name @java_opts
+      agent_name @java_opts, credentials
+      add_url @java_opts, credentials
+      agent_manager_credential @java_opts, credentials
+
+      @java_opts
+    end
+
+    private
+
+    # Name of the CA APM service
+    FILTER = /introscope/
+
+    # Checks to see whether the service exists based on the agent_manager_url.
+    def service_exists?
+      @services.one_service?(FILTER, 'agent_manager_url')
+    end
+
+    def app_has_name?
+      !@vcap_application.nil? && !vcap_app_name.nil? && !vcap_app_name.empty?
+    end
+
+    def vcap_app_name
+      @vcap_application['application_name']
+    end
+
+    def process_config
+      begin
+        @version, @uri = LibertyBuildpack::Repository::ConfiguredItem.find_item(@configuration)
+      rescue => e
+        @logger.error("Unable to process the configuration for the CA APM Agent framework. #{e.message}")
+      end
+
+      @version.nil? ? nil : "introscope-agent-#{@version}"
+    end
+
+    def add_url(java_opts, credentials)
+      agent_manager = agent_manager_url(credentials)
+
+      host, port, socket_factory = parse_url(agent_manager)
+      java_opts << "-DagentManager.url.1=#{agent_manager}"
+      java_opts << "-Dintroscope.agent.enterprisemanager.transport.tcp.host.DEFAULT=#{host}"
+      java_opts << "-Dintroscope.agent.enterprisemanager.transport.tcp.port.DEFAULT=#{port}"
+      java_opts << "-Dintroscope.agent.enterprisemanager.transport.tcp.socketfactory.DEFAULT=#{socket_factory}"
+    end
+
+    # Parse the agent manager url, split first by '://', and then with ':'
+    # components is of the format [host, port, socket_factory]
+    def parse_url(url)
+      components = url.split('://')
+      components.unshift('') if components.length == 1
+      components[1] = components[1].split(':')
+      components.flatten!
+      components.push(protocol_mapping(components[0]))
+      components.shift
+      components
+    end
+
+    def protocol_mapping(protocol)
+      socket_factory_base = 'com.wily.isengard.postofficehub.link.net.'
+
+      protocol_socket_factory = {
+        ''      => socket_factory_base + 'DefaultSocketFactory',
+        'ssl'   => socket_factory_base + 'SSLSocketFactory',
+        'http'  => socket_factory_base + 'HttpTunnelingSocketFactory',
+        'https' => socket_factory_base + 'HttpsTunnelingSocketFactory'
+      }
+
+      protocol_socket_factory[protocol] || protocol
+    end
+
+    def agent_host_name(java_opts)
+      java_opts << "-Dintroscope.agent.hostName=#{@vcap_application['application_uris'][0]}"
+    end
+
+    def agent_name(java_opts, credentials)
+      name = credentials['agent_name'] || vcap_app_name
+      java_opts << "-Dintroscope.agent.agentName=#{name}"
+    end
+
+    def agent_manager_url(credentials)
+      credentials['agent_manager_url']
+    end
+
+    def agent_manager_credential(java_opts, credentials)
+      credential = credentials['agent_manager_credential']
+      java_opts << "-DagentManager.credential=#{credential}" if credential
+    end
+
+    def download_and_install_agent(home)
+      LibertyBuildpack::Util.download_tar(@version, @uri, 'CA APM Agent', home)
+    rescue => error
+      raise "Unable to download the CA APM Agent artifact. Ensure that the agent artifact at #{@uri} is available and accessible. #{error.message}"
+    end
+  end
+end

--- a/lib/liberty_buildpack/util/download.rb
+++ b/lib/liberty_buildpack/util/download.rb
@@ -56,4 +56,21 @@ module LibertyBuildpack::Util
     end
   end
 
+  # Downloads and expands a tar file.
+  #
+  # @param [LibertyBuildpack::Util::TokenizedVersion] version the version of the item
+  # @param [String] uri the URI of the item
+  # @param [String] description a description of the item
+  # @param [String] target_directory the path of the directory into which to download the item
+  def self.download_tar(version, uri, description, target_directory)
+    download_start_time = Time.now
+    print "-----> Downloading #{description} #{version} from #{uri} "
+    LibertyBuildpack::Util::Cache::ApplicationCache.new.get(uri) do |file|
+      puts "(#{(Time.now - download_start_time).duration})"
+      print '         Expanding archive ... '
+      install_start_time = Time.now
+      LibertyBuildpack::Container::ContainerUtils.untar(file, target_directory)
+      puts "(#{(Time.now - install_start_time).duration})\n"
+    end
+  end
 end

--- a/spec/liberty_buildpack/framework/ca_apm_agent_spec.rb
+++ b/spec/liberty_buildpack/framework/ca_apm_agent_spec.rb
@@ -1,0 +1,191 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2018 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+require 'spec_helper'
+require 'component_helper'
+require 'liberty_buildpack/framework/ca_apm_agent'
+require 'liberty_buildpack/container/common_paths'
+
+module LibertyBuildpack::Framework
+
+  describe 'CA APM Agent ' do
+    include_context 'component_helper' # component context
+
+    let(:ca_apm_home) { '.ca_apm' }
+    let(:application_cache) { double('ApplicationCache') }
+    let(:version) { '10.6.0_122' }
+    let(:detect_string) { "introscope-agent-#{version}" }
+
+    before do |example|
+
+      # an index.yml entry returned from the index.yml of the ca apm repository
+      if example.metadata[:index_version]
+        index_version = example.metadata[:index_version]
+        index_uri = example.metadata[:index_uri]
+
+      # defaults
+      else
+        index_version = version
+        index_uri = "https://ca.bintray.com/websphere/IntroscopeAgentFiles-NoInstaller#{version}websphere.unix.tar"
+      end
+
+      # By default, always stub the return of a valid index.yml entry
+      find_item = example.metadata[:return_find_item].nil? ? true : example.metadata[:return_find_item]
+
+      if find_item
+        index_yml_entry = [LibertyBuildpack::Util::TokenizedVersion.new(index_version), index_uri]
+        LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item).and_return(index_yml_entry)
+      else
+        # tests can set find_item=false and a raise_error_message to mock a failed return of processing the index.yml
+        LibertyBuildpack::Repository::ConfiguredItem.stub(:find_item).and_raise(example.metadata[:raise_error_message])
+      end
+
+      # For a download request of a ca apm agent jar, return the fixture jar
+      LibertyBuildpack::Util::Cache::ApplicationCache.stub(:new).and_return(application_cache)
+      application_cache.stub(:get).with(index_uri).and_yield(File.open('spec/fixtures/stub-ca-apm-agent.zip'))
+
+    end
+
+    describe 'detect',
+             vcap_application_context: { 'application_version' => 'test-version',
+                                         'application_name' => 'liberty_app',
+                                         'application_uris' => ['liberty_app.example.com'] } do
+
+      subject(:detected) { CAAPMAgent.new(context).detect }
+
+      context 'user provided service' do
+        def_type = 'servicetype'
+        def_label = 'user-provided'
+        def_tags = ['atag']
+        def_credentials = { 'agent_manager_url' => 'localhost:5001' }
+
+        it 'should be detected when the service name is introscope and agent_manager_url is present', vcap_services_context: { def_type =>
+                                                   [{ 'name' => 'introscope',
+                                                      'label' => def_label,
+                                                      'tags' => def_tags,
+                                                      'credentials' => def_credentials }] } do
+          expect(detected).to eq(detect_string)
+        end
+
+        it 'should not be detected when the service name is anything besides introscope', vcap_services_context: { def_type =>
+                                                   [{ 'name' => 'test-service-name',
+                                                      'label' => def_label,
+                                                      'tags' => def_tags,
+                                                      'credentials' => def_credentials }] } do
+          expect(detected).to eq(nil)
+        end
+
+        it 'should not be detected when the service name is intrscope but the agent_manager_url is missing', vcap_services_context: { def_type =>
+                                                   [{ 'name' => 'test-service-name',
+                                                      'label' => def_label,
+                                                      'tags' => def_tags,
+                                                      'credentials' => nil }] } do
+          expect(detected).to eq(nil)
+        end
+
+        it 'should not be detected when the service name is intrscope but agent_manager_url key has typos',
+           vcap_services_context: { def_type => [{ 'name' => 'test-service-name', 'label' => def_label, 'tags' => def_tags, 'credentials' => { 'agent-manager-url' => 'localhost' } }] } do
+          expect(detected).to eq(nil)
+        end
+      end
+    end
+
+    describe 'compile', vcap_application_context: { 'application_version' => 'test-version',
+                                                    'application_name' => 'liberty_app',
+                                                    'application_uris' => ['liberty_app.example.com'] }, vcap_services_context: { 'introscope' =>
+                                                                                                                                      [{ 'name' => 'introscope',
+                                                                                                                                         'label' => 'introscope',
+                                                                                                                                         'credentials' => { 'agent_manager_url' => 'localhost:5001' } }] } do
+
+      subject(:compiled) do
+        ca_apm = CAAPMAgent.new(context)
+        ca_apm.detect
+        ca_apm.compile
+      end
+
+      it 'should create a ca apm home directory in the application root' do
+        compiled
+        expect(Dir.exist?(File.join(app_dir, ca_apm_home))).to eq(true)
+      end
+
+      describe 'download agent tar based on index.yml' do
+        it 'should download the agent tar based on the version key' do
+          expect {compiled}.to output(%r{ Downloading CA APM Agent #{version} from https://ca.bintray.com/websphere/IntroscopeAgentFiles-NoInstaller#{version}websphere.unix.tar }).to_stdout
+        end
+      end
+    end
+
+    describe 'release', configuration: {}, vcap_application_context: { 'application_version' => 'test-version',
+                                                                       'application_name' => 'liberty_app',
+                                                                       'application_uris' => ['liberty_app.example.com'] } do
+      subject(:released) do
+        ca_apm = CAAPMAgent.new(context)
+        ca_apm.detect
+        ca_apm.release
+      end
+
+      it 'should return non nil java command line options for the introscope service',
+         java_opts: [],
+         vcap_services_context: { 'introscope' =>
+                                     [{ 'name' => 'introscope',
+                                        'label' => 'introscope',
+                                        'credentials' => { 'agent_manager_url' => 'localhost:5001' } }] } do
+        java_opts = released
+        expect(java_opts).not_to eq(nil)
+        expect(java_opts.size).to eq(9)
+      end
+
+      it 'should return java command line options for the introscope service',
+         java_opts: [],
+         vcap_services_context: { 'introscope' =>
+                                     [{ 'name' => 'introscope',
+                                        'label' => 'introscope',
+                                        'credentials' => { 'agent_manager_url' => 'localhost:5001' } }] } do
+
+        java_opts = released
+        expect(java_opts).to include("-javaagent:./#{ca_apm_home}/wily/AgentNoRedefNoRetrans.jar")
+        expect(java_opts).to include('-Dorg.osgi.framework.bootdelegation=com.wily.*')
+        expect(java_opts).to include(/-Dcom.wily.introscope.agentProfile=.*\/wily\/core\/config\/IntroscopeAgent.NoRedef.profile/)
+        expect(java_opts).to include('-Dintroscope.agent.hostName=liberty_app.example.com')
+        expect(java_opts).to include('-Dintroscope.agent.agentName=liberty_app')
+        expect(java_opts).to include('-DagentManager.url.1=localhost:5001')
+        expect(java_opts).to include('-Dintroscope.agent.enterprisemanager.transport.tcp.host.DEFAULT=localhost')
+        expect(java_opts).to include('-Dintroscope.agent.enterprisemanager.transport.tcp.port.DEFAULT=5001')
+        expect(java_opts).to include('-Dintroscope.agent.enterprisemanager.transport.tcp.socketfactory.DEFAULT=com.wily.isengard.postofficehub.link.net.DefaultSocketFactory')
+      end
+
+      it 'should return java command line options for the introscope service and have the agent manager credential if present',
+         java_opts: [],
+         vcap_services_context: { 'introscope' =>
+                                     [{  'name' => 'introscope',
+                                         'label' => 'introscope',
+                                         'credentials' => { 'agent_manager_url' => 'localhost:5001', 'agent_manager_credential' => 'test1234abcdf' } }] } do
+
+        java_opts = released
+        expect(java_opts).to include("-javaagent:./#{ca_apm_home}/wily/AgentNoRedefNoRetrans.jar")
+        expect(java_opts).to include('-Dorg.osgi.framework.bootdelegation=com.wily.*')
+        expect(java_opts).to include(/-Dcom.wily.introscope.agentProfile=.*\/wily\/core\/config\/IntroscopeAgent.NoRedef.profile/)
+        expect(java_opts).to include('-Dintroscope.agent.hostName=liberty_app.example.com')
+        expect(java_opts).to include('-Dintroscope.agent.agentName=liberty_app')
+        expect(java_opts).to include('-DagentManager.url.1=localhost:5001')
+        expect(java_opts).to include('-Dintroscope.agent.enterprisemanager.transport.tcp.host.DEFAULT=localhost')
+        expect(java_opts).to include('-Dintroscope.agent.enterprisemanager.transport.tcp.port.DEFAULT=5001')
+        expect(java_opts).to include('-Dintroscope.agent.enterprisemanager.transport.tcp.socketfactory.DEFAULT=com.wily.isengard.postofficehub.link.net.DefaultSocketFactory')
+        expect(java_opts).to include('-DagentManager.credential=test1234abcdf')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Before this commit, the liberty buildpack did not contain support for CA APM's Java Agent. 
After this commit, users can successfully instrument applications with CA APM's Java Agent.