### PR TITLE
Update JRebel version

### DIFF
--- a/config/jrebelagent.yml
+++ b/config/jrebelagent.yml
@@ -15,6 +15,6 @@
 
 # Service configuration
 ---
-version: 7.+
+version: +
 repository_root: "https://dl.zeroturnaround.com/jrebel/"
 enabled: true


### PR DESCRIPTION
JRebel now follows a versioning scheme where the "major" version is the
year when that version was released. As such, it doesn't make sense to
fix a specific major version anymore.