### PR TITLE
Use small footprint IBM JRE

### DIFF
--- a/config/ibmjdk.yml
+++ b/config/ibmjdk.yml
@@ -15,7 +15,7 @@
 
 # Configuration for JRE repository
 ---
-repository_root: "https://public.dhe.ibm.com/ibmdl/export/pub/systems/cloud/runtimes/java/meta/jre/linux/x86_64/"
+repository_root: "https://public.dhe.ibm.com/ibmdl/export/pub/systems/cloud/runtimes/java/meta/sfj/linux/x86_64/"
 version: 1.8.+
 
 heap_size_ratio: 0.75


### PR DESCRIPTION
It's a headless version of the full JRE. It's smaller so faster downloads and deployments.
