### PR TITLE
Update openjdk.rb

### DIFF
--- a/lib/liberty_buildpack/jre/openjdk.rb
+++ b/lib/liberty_buildpack/jre/openjdk.rb
@@ -108,13 +108,13 @@ module LibertyBuildpack::Jre
       FileUtils.mkdir_p(java_home)
 
       system "tar xzf #{file.path} -C #{java_home} --strip 1 2>&1"
-      
+
       if system("[ $(ls #{java_home} | wc -l) = 1 ]")
         FileUtils.rm_rf(java_home)
         FileUtils.mkdir_p(java_home)
         system "tar xzf #{file.path} -C #{java_home} --strip 2 2>&1"
       end
-      
+
       puts "(#{(Time.now - expand_start_time).duration})"
     end
 

--- a/lib/liberty_buildpack/jre/openjdk.rb
+++ b/lib/liberty_buildpack/jre/openjdk.rb
@@ -108,6 +108,13 @@ module LibertyBuildpack::Jre
       FileUtils.mkdir_p(java_home)
 
       system "tar xzf #{file.path} -C #{java_home} --strip 1 2>&1"
+      
+      if system("[ $(ls #{java_home} | wc -l) = 1 ]")
+        FileUtils.rm_rf(java_home)
+        FileUtils.mkdir_p(java_home)
+        system "tar xzf #{file.path} -C #{java_home} --strip 2 2>&1"
+      end
+      
       puts "(#{(Time.now - expand_start_time).duration})"
     end
 

--- a/lib/liberty_buildpack/jre/openjdk.rb
+++ b/lib/liberty_buildpack/jre/openjdk.rb
@@ -109,7 +109,7 @@ module LibertyBuildpack::Jre
 
       system "tar xzf #{file.path} -C #{java_home} --strip 1 2>&1"
 
-      if system("[ $(ls #{java_home} | wc -l) = 1 ]") && system("[ ! $(ls #{java_home} | grep 'jre') ]")
+      if system("[ $(ls #{java_home} | wc -l) = 1 ]") && system("[ ! $(ls #{java_home} | grep -w 'jre') ]")
         FileUtils.rm_rf(java_home)
         FileUtils.mkdir_p(java_home)
         system "tar xzf #{file.path} -C #{java_home} --strip 2 2>&1"

--- a/lib/liberty_buildpack/jre/openjdk.rb
+++ b/lib/liberty_buildpack/jre/openjdk.rb
@@ -109,7 +109,7 @@ module LibertyBuildpack::Jre
 
       system "tar xzf #{file.path} -C #{java_home} --strip 1 2>&1"
 
-      if system("[ $(ls #{java_home} | wc -l) = 1 ]") and system("[ ! $(ls #{java_home} | grep 'jre') ]")
+      if system("[ $(ls #{java_home} | wc -l) = 1 ]") && system("[ ! $(ls #{java_home} | grep 'jre') ]")
         FileUtils.rm_rf(java_home)
         FileUtils.mkdir_p(java_home)
         system "tar xzf #{file.path} -C #{java_home} --strip 2 2>&1"

--- a/lib/liberty_buildpack/jre/openjdk.rb
+++ b/lib/liberty_buildpack/jre/openjdk.rb
@@ -109,7 +109,7 @@ module LibertyBuildpack::Jre
 
       system "tar xzf #{file.path} -C #{java_home} --strip 1 2>&1"
 
-      if system("[ $(ls #{java_home} | wc -l) = 1 ]")
+      if system("[ $(ls #{java_home} | wc -l) = 1 ]") and system("[ ! $(ls #{java_home} | grep 'jre') ]")
         FileUtils.rm_rf(java_home)
         FileUtils.mkdir_p(java_home)
         system "tar xzf #{file.path} -C #{java_home} --strip 2 2>&1"


### PR DESCRIPTION
Currently there is an issue with trying to use the openJDK because they zip up the ./ dir. When it gets unpacked, there is an extra top level directory. This code checks to see if there is a single directory not named jre (assumed to be the extra top level) and will delete it and then re-extract and trim properly.