### PR TITLE
OpenJ9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ All Documentation is available in the Docs folder of the buildpack.
     * [JRebel Agent](docs/framework-jrebel-agent.md)
     * [New Relic Agent](docs/framework-new-relic-agent.md)
     * [Spring Auto Reconfiguration](docs/framework-spring-auto-reconfiguration.md)
-* JREs
-    * [IBM JRE](docs/ibm-jdk.md)
+* JVMs
+    * [IBM SDK](docs/ibm-jdk.md)
     * [OpenJDK](docs/open-jdk.md)
+    * [OpenJ9](docs/openj9.md)
 * [Server Behavior xml Options](docs/server-xml-options.md)
 * [Forking the buildpack](docs/forking.md)
 * [Overriding buildpack configuration](docs/configuration.md)

--- a/config/components.yml
+++ b/config/components.yml
@@ -22,6 +22,7 @@ containers:
 jres:
   - "LibertyBuildpack::Jre::IBMJdk"
   - "LibertyBuildpack::Jre::OpenJdk"
+  - "LibertyBuildpack::Jre::OpenJ9"
 frameworks:
   - "LibertyBuildpack::Framework::Env"
   - "LibertyBuildpack::Framework::JavaOpts"

--- a/config/openj9.yml
+++ b/config/openj9.yml
@@ -1,0 +1,22 @@
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2013-2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration for OpenJdk+OpenJ9
+# Please see the documentation for more detail.
+---
+version: 11.+
+type: jre
+heap_size: normal
+heap_size_ratio: 0.75

--- a/docs/ibm-jdk.md
+++ b/docs/ibm-jdk.md
@@ -1,5 +1,5 @@
-# IBM JRE
-The IBM JRE is the default JRE used by the Liberty buildpack. Unless otherwise configured, the version of IBM JRE that will be used is specified in the [`config/ibmjdk.yml`][] file. If necessary, the IBM JRE can also be explicitly enabled by setting the `JVM` environment variable to `ibmjdk`. For example, using the `manifest.yml` file:
+# IBM SDK
+The [IBM SDK](https://www.ibm.com/support/knowledgecenter/en/SSYKE2/welcome_javasdk_family.html) is the default JVM used by the Liberty buildpack. Unless otherwise configured, the version of IBM SDK that will be used is specified in the [`config/ibmjdk.yml`][] file. If necessary, the IBM SDK can also be explicitly enabled by setting the `JVM` environment variable to `ibmjdk`. For example, using the `manifest.yml` file:
 
 ```bash
 ---
@@ -7,11 +7,11 @@ env:
   JVM: ibmjdk
 ```
 
-The Liberty buildpack also supports [OpenJDK](open-jdk.md) as an alternative Java runtime.
+The Liberty buildpack also supports [OpenJDK](open-jdk.md) and [OpenJ9](openj9.md) as alternative JVMs.
 
 ## Configuration
 
-The JRE can be configured by modifying the [`config/ibmjdk.yml`][] file in the buildpack fork or by passing [an environment variable](configuration.md) that overrides configuration in the yml file. 
+IBM SDK can be configured by modifying the [`config/ibmjdk.yml`][] file in the buildpack fork or by passing [an environment variable](configuration.md) that overrides configuration in the yml file.
 
 | Name | Description
 | ---- | -----------
@@ -21,7 +21,7 @@ The JRE can be configured by modifying the [`config/ibmjdk.yml`][] file in the b
 
 ## Common Configuration Overrides
 
-The IBM JRE [configuration can be overridden](configuration.md) with the `JBP_CONFIG_IBMJDK` environment variable. The value of the variable should be valid inline YAML. For example:
+The IBM SDK [configuration can be overridden](configuration.md) with the `JBP_CONFIG_IBMJDK` environment variable. The value of the variable should be valid inline YAML. For example:
 
 1. Adjust heap size ratio:
 
@@ -29,7 +29,7 @@ The IBM JRE [configuration can be overridden](configuration.md) with the `JBP_CO
    $ cf set-env myApplication JBP_CONFIG_IBMJDK 'heap_size_ratio: 0.90'
    ```
 
-1. Use IBM JRE version 7:
+1. Use IBM SDK version 7:
 
    ```bash
    $ cf set-env myApplication JBP_CONFIG_IBMJDK 'version: 1.7.+'
@@ -38,4 +38,3 @@ The IBM JRE [configuration can be overridden](configuration.md) with the `JBP_CO
 [`config/ibmjdk.yml`]: ../config/ibmjdk.yml
 [index.yml]: http://public.dhe.ibm.com/ibmdl/export/pub/systems/cloud/runtimes/java/meta/jre/linux/x86_64/index.yml
 [repositories]: util-repositories.md
-

--- a/docs/open-jdk.md
+++ b/docs/open-jdk.md
@@ -1,5 +1,5 @@
 # OpenJDK JRE
-The OpenJDK JRE provides Java runtimes from the [OpenJDK][] project. The OpenJDK JRE must be explicitly enabled to be used by the Liberty buildpack. To enable OpenJDK JRE set the `JVM` environment variable to `openjdk`. For example, add the following to your *manifest.yml* file:
+The OpenJDK JRE provides JVM from the [OpenJDK][] project. The OpenJDK JRE must be explicitly enabled to be used by the Liberty buildpack. To enable OpenJDK JRE set the `JVM` environment variable to `openjdk`. For example, add the following to your *manifest.yml* file:
 
 ```bash
 ---
@@ -9,11 +9,11 @@ env:
 
 Unless otherwise configured, the version of OpenJDK JRE that will be used is specified in the [`config/openjdk.yml`][] file. Versions of Java from the `1.6`, `1.7`, and `1.8` lines are available.
 
-The Liberty buildpack uses the [IBM JRE](ibm-jdk.md) by default.
+The Liberty buildpack uses the [IBM SDK](ibm-jdk.md) by default.
 
 ## Configuration
 
-The JRE can be configured by modifying the [`config/openjdk.yml`][] file in the buildpack fork or by passing [an environment variable](configuration.md) that overrides configuration in the yml file. 
+The JRE can be configured by modifying the [`config/openjdk.yml`][] file in the buildpack fork or by passing [an environment variable](configuration.md) that overrides configuration in the yml file.
 
 | Name | Description
 | ---- | -----------
@@ -94,4 +94,3 @@ The environment variables can also be specified in the [manifest.yml](http://doc
 [OpenJDK]: http://openjdk.java.net
 [precise]: http://download.pivotal.io.s3.amazonaws.com/openjdk/precise/x86_64/index.yml
 [repositories]: util-repositories.md
-

--- a/docs/openj9.md
+++ b/docs/openj9.md
@@ -1,0 +1,43 @@
+# OpenJ9
+The [OpenJ9][] is an alternative Java virtual machine from the [Eclipse Foundation](https://eclipse.org). The OpenJ9 JVM must be explicitly enabled to be used by the Liberty buildpack. To enable OpenJ9 set the `JVM` environment variable to the `openj9` value. For example, add the following to your *manifest.yml* file:
+
+```bash
+---
+env:
+  JVM: openj9
+```
+
+Unless otherwise configured, the version of OpenJ9 that will be used is specified in the [`config/openj9.yml`][] file. Versions of Java from the `8` and `11` lines are currently available.
+
+The Liberty buildpack uses the [IBM SDK](ibm-jdk.md) by default.
+
+## Configuration
+
+OpenJ9 can be configured by modifying the [`config/openj9.yml`][] file in the buildpack fork or by passing [an environment variable](configuration.md) that overrides configuration in the yml file.
+
+| Name | Description
+| ---- | -----------
+| `version` | The version of OpenJ9 to use. Candidate versions can be found on the [AdpotOpenJDK page](https://adoptopenjdk.net/index.html?jvmVariant=openj9). |
+| `type`  | `jre` (default) or `jdk`. |
+| `heap_size` | `normal` (default) or `large`.   |
+| `heap_size_ratio` | The ratio that is used to calculate the maximum heap size. The default heap size ratio is `0.75` (75% of the total available memory).
+
+## Common Configuration Overrides
+
+The OpenJ9 [configuration can be overridden](configuration.md) with the `JBP_CONFIG_OPENJ9` environment variable. The value of the variable should be valid inline YAML. For example:
+
+1. Use OpenJ9 version 8:
+
+   ```bash
+   $ cf set-env myApplication JBP_CONFIG_OPENJ9 'version: 8.+'
+   ```
+
+1. Use full JDK instead of JRE:
+
+   ```bash
+   $ cf set-env myApplication JBP_CONFIG_OPENJ9 'type: jdk'
+   ```
+
+[`config/openj9.yml`]: ../config/openj9.yml
+[OpenJ9]: https://www.eclipse.org/openj9/
+[repositories]: util-repositories.md

--- a/lib/liberty_buildpack/jre/adopt_openjdk.rb
+++ b/lib/liberty_buildpack/jre/adopt_openjdk.rb
@@ -1,0 +1,122 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2013-2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'liberty_buildpack/container/common_paths'
+require 'liberty_buildpack/repository/configured_item'
+require 'liberty_buildpack/util/format_duration'
+require 'liberty_buildpack/util/tokenized_version'
+require 'liberty_buildpack/util/cache/application_cache'
+
+module LibertyBuildpack::Jre
+
+  # Encapsulates the detect, compile, and release functionality for selecting an OpenJDK JRE.
+  class AdoptOpenJdk
+
+    # Creates an instance, passing in an arbitrary collection of options.
+    #
+    # @param [Hash] context the context that is provided to the instance
+    # @option context [String] :app_dir the directory that the application exists in
+    # @option context [String] :java_home the directory that acts as +JAVA_HOME+
+    # @option context [Array<String>] :java_opts an array that Java options can be added to
+    # @option context [Hash] :configuration the properties provided by the user
+    # @option contect [String] :jvm_type the type of jvm the user wants to use e.g ibmjre or openjdk
+    def initialize(context)
+      @app_dir = context[:app_dir]
+      @java_opts = context[:java_opts]
+      @configuration = context[:configuration]
+      @common_paths = context[:common_paths] || LibertyBuildpack::Container::CommonPaths.new
+      @jvm_type = context[:jvm_type]
+      context[:java_home].concat JAVA_HOME unless context[:java_home].include? JAVA_HOME
+    end
+
+    # Downloads and unpacks a OpenJdk
+    #
+    # @return [void]
+    def install_jdk
+      release = find_openjdk(@configuration)
+      uri = release['binaries'][0]['binary_link']
+      @version = release['release_name']
+      download_start_time = Time.now
+
+      print "-----> Downloading OpenJDK #{@version} from #{uri} "
+
+      LibertyBuildpack::Util::Cache::ApplicationCache.new.get(uri) do |file| # TODO: Use global cache
+        puts "(#{(Time.now - download_start_time).duration})"
+        expand file
+      end
+    end
+
+    private
+
+    def java_home
+      File.join @app_dir, JAVA_HOME
+    end
+
+    JAVA_HOME = '.java'.freeze
+
+    def expand(file)
+      expand_start_time = Time.now
+      print "       Expanding OpenJDK to #{JAVA_HOME} "
+
+      FileUtils.rm_rf(java_home)
+      FileUtils.mkdir_p(java_home)
+
+      # AdoptOpenJDKs do not have jre/bin/java so that's ok
+      depth = `tar tf #{file.path} | grep '/bin/java$' | grep -o / | wc -l`
+      system "tar xzf #{file.path} -C #{java_home} --strip #{depth.to_i - 1} 2>&1"
+
+      puts "(#{(Time.now - expand_start_time).duration})"
+    end
+
+    def find_openjdk(configuration)
+      requested_version = LibertyBuildpack::Util::TokenizedVersion.new(configuration['version'])
+      uri = openjdk_uri(requested_version, configuration['type'], configuration['heap_size'])
+      cache.get(uri) do |file|
+        releases = JSON.load(file)
+        raise 'No OpenJDK versions found' if releases.length == 0
+
+        candidates = {}
+        releases.each do |release|
+          binary_entry = release['binaries'][0]
+          version_data = binary_entry['version_data']
+          next if version_data.nil?
+
+          sanitized_version = version_data['semver'].gsub(/\+.*$/, '')
+          version = LibertyBuildpack::Util::TokenizedVersion.new(sanitized_version)
+          candidates[version.to_s] = release
+        end
+
+        found_version = LibertyBuildpack::Repository::VersionResolver.resolve(requested_version, candidates.keys)
+        raise "No version resolvable for '#{requested_version}' in #{candidates.keys.join(', ')}" if found_version.nil?
+        found_release = candidates[found_version.to_s]
+        return found_release
+      end
+    rescue => e
+      raise RuntimeError, "OpenJDK error: #{e.message}", e.backtrace
+    end
+
+    def cache
+      LibertyBuildpack::Util::Cache::DownloadCache.new(Pathname.new(Dir.tmpdir),
+                                                       LibertyBuildpack::Util::Cache::CACHED_RESOURCES_DIRECTORY)
+    end
+
+    def openjdk_uri(version, type, heap_size)
+      "https://api.adoptopenjdk.net/v2/info/releases/openjdk#{version[0]}?openjdk_impl=#{implementation}&type=#{type}&arch=x64&os=linux&heap_size=#{heap_size}"
+    end
+
+  end
+
+end

--- a/lib/liberty_buildpack/jre/openj9.rb
+++ b/lib/liberty_buildpack/jre/openj9.rb
@@ -1,0 +1,135 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2013-2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'liberty_buildpack/jre/adopt_openjdk'
+
+module LibertyBuildpack::Jre
+
+  # Encapsulates the detect, compile, and release functionality for selecting an OpenJDK JRE.
+  class OpenJ9 < AdoptOpenJdk
+
+    # The ratio of heap reservation to total reserved memory
+    HEAP_SIZE_RATIO = 0.75
+
+    # Filename of killjava script used to kill the JVM on OOM.
+    KILLJAVA_FILE_NAME = 'killjava.sh'.freeze
+
+    # Creates an instance, passing in an arbitrary collection of options.
+    #
+    # @param [Hash] context the context that is provided to the instance
+    # @option context [String] :app_dir the directory that the application exists in
+    # @option context [String] :java_home the directory that acts as +JAVA_HOME+
+    # @option context [Array<String>] :java_opts an array that Java options can be added to
+    # @option context [CommonPaths] :common_paths the set of paths common across components that components should reference
+    # @option context [Hash] :license_ids the licenses accepted by the user
+    # @option contect [String] :jvm_type the type of jvm the user wants to use e.g ibmjre or openjdk
+    # @option context [Hash] :configuration the properties provided by the user
+    def initialize(context)
+      super(context)
+    end
+
+    # Detects which version of Java this application should use.  *NOTE:* This method will only return a value
+    # if the jvm_type is set to openjdk.
+    #
+    # @return [String, nil] returns +openj9-<version>+.
+    def detect
+      if !@jvm_type.nil? && 'openj9'.casecmp(@jvm_type) == 0
+        release = find_openjdk(@configuration)
+        id(release['release_name'])
+      end
+    end
+
+    # Downloads and unpacks a JRE
+    #
+    # @return [void]
+    def compile
+      install_jdk
+      copy_killjava_script
+      write_heap_size_ratio_file
+    end
+
+    # Build Java memory options and places then in +context[:java_opts]+
+    #
+    # @return [void]
+    def release
+      @java_opts.concat memory_opts
+      @java_opts.concat default_dump_opts
+      @java_opts << '-Xshareclasses:none'
+      @java_opts << "-Xdump:tool:events=systhrow,filter=java/lang/OutOfMemoryError,request=serial+exclusive,exec=#{@common_paths.diagnostics_directory}/#{KILLJAVA_FILE_NAME}"
+    end
+
+    private
+
+    RESOURCES = '../../../resources/ibmjdk/diagnostics'.freeze
+
+    MEMORY_CONFIG_FOLDER = '.memory_config/'.freeze
+
+    HEAP_RATIO_FILE = 'heap_size_ratio_config'.freeze
+
+    def implementation
+      'openj9'
+    end
+
+    def id(version)
+      "openj9-#{version}"
+    end
+
+    def memory_opts
+      java_memory_opts = []
+      java_memory_opts.push '-Xtune:virtualized'
+
+      java_memory_opts
+    end
+
+    def heap_size_ratio_file
+      File.join(@app_dir, MEMORY_CONFIG_FOLDER, HEAP_RATIO_FILE)
+    end
+
+    def write_heap_size_ratio_file
+      FileUtils.mkdir_p File.join(@app_dir, MEMORY_CONFIG_FOLDER)
+      File.open(heap_size_ratio_file, 'w') { |file| file.write(heap_size_ratio) }
+    end
+
+    def heap_size_ratio
+      @configuration['heap_size_ratio'] || HEAP_SIZE_RATIO
+    end
+
+    # default options for -Xdump to disable dumps while routing to the default dumps location when it is enabled by the
+    # user
+    def default_dump_opts
+      default_options = []
+      default_options.push '-Xdump:none'
+      default_options.push "-Xdump:heap:defaults:file=#{@common_paths.dump_directory}/heapdump.%Y%m%d.%H%M%S.%pid.%seq.phd"
+      default_options.push "-Xdump:java:defaults:file=#{@common_paths.dump_directory}/javacore.%Y%m%d.%H%M%S.%pid.%seq.txt"
+      default_options.push "-Xdump:snap:defaults:file=#{@common_paths.dump_directory}/Snap.%Y%m%d.%H%M%S.%pid.%seq.trc"
+      default_options.push '-Xdump:heap+java+snap:events=user'
+      default_options
+    end
+
+    def copy_killjava_script
+      resources = File.expand_path(RESOURCES, File.dirname(__FILE__))
+      killjava_file_content = File.read(File.join(resources, KILLJAVA_FILE_NAME))
+      updated_content = killjava_file_content.gsub(/@@LOG_FILE_NAME@@/, LibertyBuildpack::Diagnostics::LOG_FILE_NAME)
+      diagnostic_dir = LibertyBuildpack::Diagnostics.get_diagnostic_directory @app_dir
+      FileUtils.mkdir_p diagnostic_dir
+      File.open(File.join(diagnostic_dir, KILLJAVA_FILE_NAME), 'w', 0o755) do |file|
+        file.write updated_content
+      end
+    end
+
+  end
+
+end

--- a/lib/liberty_buildpack/jre/openjdk.rb
+++ b/lib/liberty_buildpack/jre/openjdk.rb
@@ -53,8 +53,10 @@ module LibertyBuildpack::Jre
     #
     # @return [String, nil] returns +ibmjdk-<version>+.
     def detect
-      @version = OpenJdk.find_openjdk(@configuration)[0]
-      id @version if !@jvm_type.nil? && 'openjdk'.casecmp(@jvm_type) == 0
+      if !@jvm_type.nil? && 'openjdk'.casecmp(@jvm_type) == 0
+        @version = OpenJdk.find_openjdk(@configuration)[0]
+        id(@version)
+      end
     end
 
     # Downloads and unpacks a OpenJdk

--- a/spec/fixtures/openj9-releases.json
+++ b/spec/fixtures/openj9-releases.json
@@ -1,0 +1,29 @@
+[
+  {
+    "release_name": "jdk-11+28",
+    "release_link": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/tag/jdk-11%2B28",
+    "timestamp": "2018-10-03T05:11:19Z",
+    "release": true,
+    "binaries": [
+      {
+        "os": "linux",
+        "architecture": "x64",
+        "binary_type": "jre",
+        "openjdk_impl": "openj9",
+        "binary_name": "OpenJDK11-jre_x64_linux_openj9_11_28.tar.gz",
+        "binary_link": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11%2B28/OpenJDK11-jre_x64_linux_openj9_11_28.tar.gz",
+        "binary_size": 40889035,
+        "checksum_link": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11%2B28/OpenJDK11-jre_x64_linux_openj9_11_28.tar.gz.sha256.txt",
+        "version": "11",
+        "version_data": {
+          "openjdk_version": "11+28",
+          "semver": "11.0.0+28"
+        },
+        "heap_size": "normal",
+        "download_count": 281,
+        "updated_at": "2018-10-03T20:38:10Z"
+      }
+    ],
+    "download_count": 2060754
+  }
+]

--- a/spec/liberty_buildpack/jre/openj9_spec.rb
+++ b/spec/liberty_buildpack/jre/openj9_spec.rb
@@ -1,0 +1,146 @@
+# Encoding: utf-8
+# IBM WebSphere Application Server Liberty Buildpack
+# Copyright 2013-2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'component_helper'
+require 'fileutils'
+require 'liberty_buildpack/jre/openj9'
+
+module LibertyBuildpack::Jre
+
+  describe OpenJ9 do
+    include_context 'component_helper'
+
+    let(:default_configuration) do
+      { 'version' => '11.+',
+        'type' => 'jre',
+        'heap_size' => 'normal' }
+    end
+
+    let(:application_cache) { double('ApplicationCache') }
+
+    def stubs
+      LibertyBuildpack::Util::Cache::DownloadCache.stub(:new).and_return(application_cache)
+      application_cache.stub(:get).with('https://api.adoptopenjdk.net/v2/info/releases/openjdk11?openjdk_impl=openj9&type=jre&arch=x64&os=linux&heap_size=normal').and_yield(File.open('spec/fixtures/openj9-releases.json'))
+      application_cache.stub(:get).with('https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11%2B28/OpenJDK11-jre_x64_linux_openj9_11_28.tar.gz').and_yield(File.open('spec/fixtures/stub-ibm-java.tar.gz'))
+    end
+
+    def openj9(root, configuration = default_configuration)
+      stubs
+      component = OpenJ9.new(
+        app_dir: root,
+        java_home: '',
+        java_opts: [],
+        configuration: configuration,
+        jvm_type: 'openj9'
+      )
+      component
+    end
+
+    it 'adds the JAVA_HOME to java_home' do
+      Dir.mktmpdir do |root|
+        java_home = ''
+
+        OpenJ9.new(
+          app_dir: root,
+          java_home: java_home,
+          java_opts: [],
+          configuration: default_configuration
+        )
+
+        expect(java_home).to eq('.java')
+      end
+    end
+
+    describe 'detect' do
+
+      it 'should detect with id of openj9-<version>' do
+        Dir.mktmpdir do |root|
+          detected = openj9(root).detect
+
+          expect(detected).to eq('openj9-jdk-11+28')
+        end
+      end
+
+    end
+
+    describe 'compile' do
+
+      it 'should extract Java from a tar gz' do
+        Dir.mktmpdir do |root|
+          openj9(root).compile
+
+          java = File.join(root, '.java', 'bin', 'java')
+          expect(File.exist?(java)).to eq(true)
+        end
+      end
+
+      it 'places the killjava script (with appropriately substituted content) in the diagnostics directory' do
+        Dir.mktmpdir do |root|
+          openj9(root).compile
+
+          expect(Pathname.new(File.join(LibertyBuildpack::Diagnostics.get_diagnostic_directory(root), OpenJ9::KILLJAVA_FILE_NAME))).to exist
+        end
+      end
+
+      it 'should add 0.50 ratio when heap_size_ratio is set to 50%' do
+        Dir.mktmpdir do |root|
+          configuration = default_configuration.clone
+          configuration['heap_size_ratio'] = '0.50'
+          openj9(root, configuration).compile
+
+          memory_config = File.read("#{root}/.memory_config/heap_size_ratio_config")
+          expect(memory_config).to include('0.5')
+        end
+      end
+
+      it 'should add 0.75 ratio when heap_size_ratio is not set' do
+        Dir.mktmpdir do |root|
+          openj9(root).compile
+
+          memory_config = File.read("#{root}/.memory_config/heap_size_ratio_config")
+          expect(memory_config).to include('0.75')
+        end
+      end
+
+    end # end of compile shared tests
+
+    describe 'release' do
+
+      subject(:released) do
+        Dir.mktmpdir do |root|
+          component = openj9(root)
+          component.detect
+          component.release
+        end
+      end
+
+      it 'should add default dump options that output data to the common dumps directory, if enabled' do
+        expect(released).to include('-Xdump:none',
+                                    '-Xshareclasses:none',
+                                    '-Xdump:heap:defaults:file=./../dumps/heapdump.%Y%m%d.%H%M%S.%pid.%seq.phd',
+                                    '-Xdump:java:defaults:file=./../dumps/javacore.%Y%m%d.%H%M%S.%pid.%seq.txt',
+                                    '-Xdump:snap:defaults:file=./../dumps/Snap.%Y%m%d.%H%M%S.%pid.%seq.trc',
+                                    '-Xdump:heap+java+snap:events=user')
+      end
+
+      it 'should provide troubleshooting info for JVM shutdowns' do
+        expect(released).to include("-Xdump:tool:events=systhrow,filter=java/lang/OutOfMemoryError,request=serial+exclusive,exec=./#{LibertyBuildpack::Diagnostics::DIAGNOSTICS_DIRECTORY}/#{OpenJ9::KILLJAVA_FILE_NAME}")
+      end
+    end
+
+  end
+end

--- a/spec/liberty_buildpack/jre/openjdk_spec.rb
+++ b/spec/liberty_buildpack/jre/openjdk_spec.rb
@@ -143,7 +143,8 @@ module LibertyBuildpack::Jre
             java_home: '',
             java_opts: [],
             configuration: configuration,
-            license_ids: {}
+            license_ids: {},
+            jvm_type: 'openjdk'
           ).detect
         end.to raise_error(/OpenJdk\ error:\ test\ error/)
       end


### PR DESCRIPTION
Add support for OpenJDK+OpenJ9 via [AdoptOpenJDK](https://adoptopenjdk.net/index.html).
 * Defaults to version 11 LTS but version can be overridden
 * Supports jre and jdk downloads
 * Normal and large heap size
 * Extensible base class that can also support OpenJDK+HotSpot from AdoptOpenJDK.
