### PR TITLE
Version fix

### DIFF
--- a/lib/liberty_buildpack/util/tokenized_version.rb
+++ b/lib/liberty_buildpack/util/tokenized_version.rb
@@ -23,7 +23,7 @@ module LibertyBuildpack::Util
     include Comparable
 
     # The wildcard component.
-    WILDCARD = '+'.freeze
+    WILDCARD = '+'
 
     # Create a tokenized version based on the input string.
     #
@@ -33,8 +33,8 @@ module LibertyBuildpack::Util
       @version = version
       @version = WILDCARD if !@version && allow_wildcards
 
-      major, tail = major_or_minor_and_tail @version
-      minor, tail = major_or_minor_and_tail tail
+      major, tail      = major_or_minor_and_tail @version
+      minor, tail      = major_or_minor_and_tail tail
       micro, qualifier = micro_and_qualifier tail
 
       concat [major, minor, micro, qualifier]
@@ -46,12 +46,12 @@ module LibertyBuildpack::Util
     # @return [Integer] A numerical representation of the comparison between two instances
     def <=>(other)
       comparison = 0
-      i = 0
-      while comparison == 0 && i < 3
+      i          = 0
+      while comparison.zero? && i < 3
         comparison = self[i].to_i <=> other[i].to_i
         i += 1
       end
-      comparison = qualifier_compare(non_nil_qualifier(self[3]), non_nil_qualifier(other[3])) if comparison == 0
+      comparison = qualifier_compare(non_nil_qualifier(self[3]), non_nil_qualifier(other[3])) if comparison.zero?
 
       comparison
     end
@@ -63,9 +63,19 @@ module LibertyBuildpack::Util
       @version
     end
 
+    # Check that this version has at most the given number of components.
+    #
+    # @param [Integer] maximum_components the maximum number of components this version is allowed to have
+    # @raise if this version has more than the given number of components
+    def check_size(maximum_components)
+      raise "Malformed version #{self}: too many version components" if self[maximum_components]
+    end
+
     private
 
-    COLLATING_SEQUENCE = ['-', '.'] + ('a'..'z').to_a + ('A'..'Z').to_a + ('0'..'9').to_a
+    COLLATING_SEQUENCE = (['-', '.'] + ('a'..'z').to_a + ('A'..'Z').to_a + ('0'..'9').to_a).freeze
+
+    private_constant :COLLATING_SEQUENCE
 
     def char_compare(c1, c2)
       COLLATING_SEQUENCE.index(c1) <=> COLLATING_SEQUENCE.index(c2)
@@ -78,6 +88,7 @@ module LibertyBuildpack::Util
       else
         raise "Invalid version '#{s}': must not end in '.'" if s[-1] == '.'
         raise "Invalid version '#{s}': missing component" if s =~ /\.[\._]/
+
         tokens = s.match(/^([^\.]+)(?:\.(.*))?/)
 
         major_or_minor, tail = tokens[1..-1]
@@ -85,7 +96,7 @@ module LibertyBuildpack::Util
         raise "Invalid major or minor version '#{major_or_minor}'" unless valid_major_minor_or_micro major_or_minor
       end
 
-      return major_or_minor, tail # rubocop:disable RedundantReturn
+      [major_or_minor, tail]
     end
 
     def micro_and_qualifier(s)
@@ -94,6 +105,7 @@ module LibertyBuildpack::Util
         qualifier = nil
       else
         raise "Invalid version '#{s}': must not end in '_'" if s[-1] == '_'
+
         tokens = s.match(/^([^\_]+)(?:_(.*))?/)
 
         micro, qualifier = tokens[1..-1]
@@ -102,7 +114,7 @@ module LibertyBuildpack::Util
         raise "Invalid qualifier '#{qualifier}'" unless valid_qualifier qualifier
       end
 
-      return micro, qualifier # rubocop:disable RedundantReturn
+      [micro, qualifier]
     end
 
     def minimum_qualifier_length(a, b)
@@ -110,15 +122,15 @@ module LibertyBuildpack::Util
     end
 
     def qualifier_compare(a, b)
-      comparison = 0
+      comparison = a[/^\d+/].to_i <=> b[/^\d+/].to_i
 
       i = 0
-      until comparison != 0 || i == minimum_qualifier_length(a, b)
+      until comparison.nonzero? || i == minimum_qualifier_length(a, b)
         comparison = char_compare(a[i], b[i])
         i += 1
       end
 
-      comparison = a.length <=> b.length if comparison == 0
+      comparison = a.length <=> b.length if comparison.zero?
 
       comparison
     end
@@ -130,10 +142,13 @@ module LibertyBuildpack::Util
     def validate(allow_wildcards)
       wildcarded = false
       each do |value|
-        raise "Invalid version '#{@version}': wildcards are not allowed this context" if value == WILDCARD && !allow_wildcards
+        if !value.nil? && value.end_with?(WILDCARD) && !allow_wildcards
+          raise "Invalid version '#{@version}': wildcards are not allowed this context"
+        end
 
-        raise "Invalid version '#{@version}': no characters are allowed after a wildcard" if wildcarded && !value.nil?
-        wildcarded = true if value == WILDCARD
+        raise "Invalid version '#{@version}': no characters are allowed after a wildcard" if wildcarded && value
+
+        wildcarded = true if !value.nil? && value.end_with?(WILDCARD)
       end
       raise "Invalid version '#{@version}': missing component" if !wildcarded && compact.length < 3
     end
@@ -143,7 +158,7 @@ module LibertyBuildpack::Util
     end
 
     def valid_qualifier(qualifier)
-      qualifier.nil? || qualifier.empty? || qualifier =~ /^[-\.a-zA-Z\d]*$/ || qualifier =~ /^\+$/
+      qualifier.nil? || qualifier.empty? || qualifier =~ /^[-\.a-zA-Z\d]*[\+]?$/
     end
   end
 

--- a/lib/liberty_buildpack/util/tokenized_version.rb
+++ b/lib/liberty_buildpack/util/tokenized_version.rb
@@ -23,7 +23,7 @@ module LibertyBuildpack::Util
     include Comparable
 
     # The wildcard component.
-    WILDCARD = '+'
+    WILDCARD = '+'.freeze
 
     # Create a tokenized version based on the input string.
     #

--- a/spec/liberty_buildpack/util/tokenized_version_spec.rb
+++ b/spec/liberty_buildpack/util/tokenized_version_spec.rb
@@ -22,106 +22,119 @@ module LibertyBuildpack::Util
   describe TokenizedVersion do
 
     it 'defaults to a wildcard if no version is supplied' do
-      expect(TokenizedVersion.new(nil)).to eq(TokenizedVersion.new('+'))
+      expect(described_class.new(nil)).to eq(described_class.new('+'))
     end
 
-    it 'should order major versions correctly' do
-      expect(TokenizedVersion.new('3.0.0')).to be > TokenizedVersion.new('2.0.0')
-      expect(TokenizedVersion.new('10.0.0')).to be > TokenizedVersion.new('2.0.0')
+    it 'orders major versions' do
+      expect(described_class.new('3.0.0')).to be > described_class.new('2.0.0')
+      expect(described_class.new('10.0.0')).to be > described_class.new('2.0.0')
     end
 
-    it 'should order minor versions correctly' do
-      expect(TokenizedVersion.new('0.3.0')).to be > TokenizedVersion.new('0.2.0')
-      expect(TokenizedVersion.new('0.10.0')).to be > TokenizedVersion.new('0.2.0')
+    it 'orders minor versions' do
+      expect(described_class.new('0.3.0')).to be > described_class.new('0.2.0')
+      expect(described_class.new('0.10.0')).to be > described_class.new('0.2.0')
     end
 
-    it 'should order micro versions correctly' do
-      expect(TokenizedVersion.new('0.0.3')).to be > TokenizedVersion.new('0.0.2')
-      expect(TokenizedVersion.new('0.0.10')).to be > TokenizedVersion.new('0.0.2')
+    it 'orders micro versions' do
+      expect(described_class.new('0.0.3')).to be > described_class.new('0.0.2')
+      expect(described_class.new('0.0.10')).to be > described_class.new('0.0.2')
     end
 
-    it 'should order qualifiers correctly' do
-      expect(TokenizedVersion.new('1.7.0_28a')).to be > TokenizedVersion.new('1.7.0_28')
+    it 'orders qualifiers' do
+      expect(described_class.new('1.7.0_28a')).to be > described_class.new('1.7.0_28')
     end
 
-    it 'should accept a qualifier with embedded periods and hyphens' do
-      TokenizedVersion.new('0.5.0_BUILD-20120731.141622-16')
+    it 'accepts a qualifier with embedded periods and hyphens' do
+      described_class.new('0.5.0_BUILD-20120731.141622-16')
     end
 
-    it 'should raise an exception when the major version is not numeric' do
-      expect { TokenizedVersion.new('A') }.to raise_error(/Invalid/)
+    it 'raises an exception when the major version is not numeric' do
+      expect { described_class.new('A') }.to raise_error(/Invalid/)
     end
 
-    it 'should raise an exception when the minor version is not numeric' do
-      expect { TokenizedVersion.new('1.A') }.to raise_error(/Invalid/)
-      expect { TokenizedVersion.new('1..0') }.to raise_error(/Invalid/)
+    it 'raises an exception when the minor version is not numeric' do
+      expect { described_class.new('1.A') }.to raise_error(/Invalid/)
+      expect { described_class.new('1..0') }.to raise_error(/Invalid/)
     end
 
-    it 'should raise an exception when the micro version is not numeric' do
-      expect { TokenizedVersion.new('1.6.A') }.to raise_error(/Invalid/)
-      expect { TokenizedVersion.new('1.6..') }.to raise_error(/Invalid/)
-      expect { TokenizedVersion.new('1.6._0') }.to raise_error(/Invalid/)
-      expect { TokenizedVersion.new('1.6_26') }.to raise_error(/Invalid/)
+    it 'raises an exception when the micro version is not numeric' do
+      expect { described_class.new('1.6.A') }.to raise_error(/Invalid/)
+      expect { described_class.new('1.6..') }.to raise_error(/Invalid/)
+      expect { described_class.new('1.6._0') }.to raise_error(/Invalid/)
+      expect { described_class.new('1.6_26') }.to raise_error(/Invalid/)
     end
 
-    it 'should raise an exception when micro version is missing' do
-      expect { TokenizedVersion.new('1.6') }.to raise_error(/Invalid/)
+    it 'accepts wildcards when legal' do
+      described_class.new('+')
+      described_class.new('1.+')
+      described_class.new('1.1.+')
+      described_class.new('1.1.1_+')
+      described_class.new('1.1.1_1+')
     end
 
-    it 'should raise an exception when major version is not legal' do
-      expect { TokenizedVersion.new('1+') }.to raise_error(/Invalid/)
+    it 'raises an exception when micro version is missing' do
+      expect { described_class.new('1.6') }.to raise_error(/Invalid/)
     end
 
-    it 'should raise an exception when minor version is not legal' do
-      expect { TokenizedVersion.new('1.6+') }.to raise_error(/Invalid/)
+    it 'raises an exception when major version is not legal' do
+      expect { described_class.new('1+') }.to raise_error(/Invalid/)
     end
 
-    it 'should raise an exception when micro version is not legal' do
-      expect { TokenizedVersion.new('1.6.0+') }.to raise_error(/Invalid/)
+    it 'raises an exception when minor version is not legal' do
+      expect { described_class.new('1.6+') }.to raise_error(/Invalid/)
     end
 
-    it 'should raise an exception when qualifier version is not legal' do
-      expect { TokenizedVersion.new('1.6.0_05+') }.to raise_error(/Invalid/)
+    it 'raises an exception when micro version is not legal' do
+      expect { described_class.new('1.6.0+') }.to raise_error(/Invalid/)
     end
 
-    it 'should raise an exception when the qualifier is not letter, number, or hyphen' do
-      expect { TokenizedVersion.new('1.6.0_?') }.to raise_error(/Invalid/)
-      expect { TokenizedVersion.new('1.6.0__5') }.to raise_error(/Invalid/)
-      expect { TokenizedVersion.new('1.6.0_A.') }.to raise_error(/Invalid/)
+    it 'raises an exception when the qualifier is not letter, number, or hyphen' do
+      expect { described_class.new('1.6.0_?') }.to raise_error(/Invalid/)
+      expect { described_class.new('1.6.0__5') }.to raise_error(/Invalid/)
+      expect { described_class.new('1.6.0_A.') }.to raise_error(/Invalid/)
     end
 
-    it 'should raise an exception when a major version wildcard is followed by anything' do
-      expect { TokenizedVersion.new('+.6.0_26') }.to raise_error(/Invalid/)
+    it 'raises an exception when a major version wildcard is followed by anything' do
+      expect { described_class.new('+.6.0_26') }.to raise_error(/Invalid/)
     end
 
-    it 'should raise an exception when a minor version wildcard is followed by anything' do
-      expect { TokenizedVersion.new('1.+.0_26') }.to raise_error(/Invalid/)
+    it 'raises an exception when a minor version wildcard is followed by anything' do
+      expect { described_class.new('1.+.0_26') }.to raise_error(/Invalid/)
     end
 
-    it 'should raise an exception when a micro version wildcard is followed by anything' do
-      expect { TokenizedVersion.new('1.6.+_26') }.to raise_error(/Invalid/)
+    it 'raises an exception when a micro version wildcard is followed by anything' do
+      expect { described_class.new('1.6.+_26') }.to raise_error(/Invalid/)
     end
 
-    it 'should raise an exception when too many components are specified' do
-      expect { TokenizedVersion.new('1.6.0.25') }.to raise_error(/Invalid/)
-      expect { TokenizedVersion.new('1.6.0.25_27') }.to raise_error(/Invalid/)
+    it 'raises an exception when too many components are specified' do
+      expect { described_class.new('1.6.0.25') }.to raise_error(/Invalid/)
+      expect { described_class.new('1.6.0.25_27') }.to raise_error(/Invalid/)
     end
 
-    it 'should raise an exception when not enough components are specified' do
-      expect { TokenizedVersion.new('_25') }.to raise_error(/Invalid/)
+    it 'raises an exception when not enough components are specified' do
+      expect { described_class.new('_25') }.to raise_error(/Invalid/)
     end
 
-    it 'should raise an exception when a wildcard is specified but should not be' do
-      expect { TokenizedVersion.new('+', false) }.to raise_error(/Invalid/)
-      expect { TokenizedVersion.new('1.+', false) }.to raise_error(/Invalid/)
-      expect { TokenizedVersion.new('1.1.+', false) }.to raise_error(/Invalid/)
-      expect { TokenizedVersion.new('1.1.1_+', false) }.to raise_error(/Invalid/)
+    it 'raises an exception when a wildcard is specified but should not be' do
+      expect { described_class.new('+', false) }.to raise_error(/Invalid/)
+      expect { described_class.new('1.+', false) }.to raise_error(/Invalid/)
+      expect { described_class.new('1.1.+', false) }.to raise_error(/Invalid/)
+      expect { described_class.new('1.1.1_+', false) }.to raise_error(/Invalid/)
+      expect { described_class.new('1.1.1_1+', false) }.to raise_error(/Invalid/)
     end
 
-    it 'should raise an exception when a version ends with a component separator' do
-      expect { TokenizedVersion.new('1.') }.to raise_error(/Invalid/)
-      expect { TokenizedVersion.new('1.7.') }.to raise_error(/Invalid/)
-      expect { TokenizedVersion.new('1.7.0_') }.to raise_error(/Invalid/)
+    it 'raises an exception when a version ends with a component separator' do
+      expect { described_class.new('1.') }.to raise_error(/Invalid/)
+      expect { described_class.new('1.7.') }.to raise_error(/Invalid/)
+      expect { described_class.new('1.7.0_') }.to raise_error(/Invalid/)
+    end
+
+    it 'accepts a version has a number of components acceptable to check_size' do
+      described_class.new('1.2.3_4').check_size(4)
+    end
+
+    it 'raises an exception when a version has too many components for check_size' do
+      expect { described_class.new('1.2.3_4').check_size(3) }.to raise_error(/too many version components/)
     end
 
   end


### PR DESCRIPTION
Pull in the latest version of tokenized_version.rb and test from Java buildpack to fix OpenJDK version download issues.
Before the change:
```
Downloading OpenJdk 1.8.0_91-unlimited-crypto from https://java-buildpack.cloudfoundry.org/openjdk/trusty/x86_64/openjdk-1.8.0_91-unlimited-crypto.tar.gz
```
After the change:
```
Downloading OpenJdk 1.8.0_202 from https://java-buildpack.cloudfoundry.org/openjdk/trusty/x86_64/openjdk-1.8.0_202.tar.gz
```