### PR TITLE
Fix file caching Issue with long URI's

### DIFF
--- a/lib/liberty_buildpack/jre/ibmjdk.rb
+++ b/lib/liberty_buildpack/jre/ibmjdk.rb
@@ -88,7 +88,6 @@ module LibertyBuildpack::Jre
       end
       LibertyBuildpack::Util::Cache::ApplicationCache.new.get(@uri) do |file| # TODO: Use global cache
         puts "(#{(Time.now - download_start_time).duration})"
-        puts "File Path: #{file.path}"
         expand file
       end
       copy_killjava_script

--- a/lib/liberty_buildpack/jre/ibmjdk.rb
+++ b/lib/liberty_buildpack/jre/ibmjdk.rb
@@ -88,6 +88,7 @@ module LibertyBuildpack::Jre
       end
       LibertyBuildpack::Util::Cache::ApplicationCache.new.get(@uri) do |file| # TODO: Use global cache
         puts "(#{(Time.now - download_start_time).duration})"
+        puts "File Path: #{file.path}"
         expand file
       end
       copy_killjava_script

--- a/lib/liberty_buildpack/util/cache/cached_file.rb
+++ b/lib/liberty_buildpack/util/cache/cached_file.rb
@@ -35,8 +35,15 @@ module LibertyBuildpack
         # @param [String] uri a uri which uniquely identifies the file in the cache
         # @param [Boolean] mutable whether the cached file should be mutable
         def initialize(cache_root, uri, mutable)
+          if @uri.include? '.bin'
+            puts "Yeah IBM, it's a binary"
+            bin_var = '.bin'
+          else
+            bin_var = ''
+          end
+
           key            = Digest::SHA256.hexdigest uri.sanitize_uri
-          @cached        = cache_root + "#{key}.cached"
+          @cached        = cache_root + "#{key}#{bin_var}.cached"
           @etag          = cache_root + "#{key}.etag"
           @last_modified = cache_root + "#{key}.last_modified"
           @mutable       = mutable

--- a/lib/liberty_buildpack/util/cache/cached_file.rb
+++ b/lib/liberty_buildpack/util/cache/cached_file.rb
@@ -26,6 +26,7 @@ module LibertyBuildpack
       #
       # Note: this class is thread-safe, however access to the cached files is not
       class CachedFile
+        include LibertyBuildpack::Util
 
         # Creates an instance of the cached file.  Files created and expected by this class will all be rooted at
         # +cache_root+.

--- a/lib/liberty_buildpack/util/cache/cached_file.rb
+++ b/lib/liberty_buildpack/util/cache/cached_file.rb
@@ -36,7 +36,6 @@ module LibertyBuildpack
         # @param [Boolean] mutable whether the cached file should be mutable
         def initialize(cache_root, uri, mutable)
           if uri.include? '.bin'
-            puts "Yeah IBM, it's a binary"
             bin_var = '.bin'
           else
             bin_var = ''

--- a/lib/liberty_buildpack/util/cache/cached_file.rb
+++ b/lib/liberty_buildpack/util/cache/cached_file.rb
@@ -35,7 +35,7 @@ module LibertyBuildpack
         # @param [String] uri a uri which uniquely identifies the file in the cache
         # @param [Boolean] mutable whether the cached file should be mutable
         def initialize(cache_root, uri, mutable)
-          if @uri.include? '.bin'
+          if uri.include? '.bin'
             puts "Yeah IBM, it's a binary"
             bin_var = '.bin'
           else

--- a/lib/liberty_buildpack/util/cache/cached_file.rb
+++ b/lib/liberty_buildpack/util/cache/cached_file.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'digest'
 require 'fileutils'
 require 'liberty_buildpack/util/cache'
 
@@ -33,7 +34,7 @@ module LibertyBuildpack
         # @param [String] uri a uri which uniquely identifies the file in the cache
         # @param [Boolean] mutable whether the cached file should be mutable
         def initialize(cache_root, uri, mutable)
-          key            = URI.escape(uri.sanitize_uri, ':/&')
+          key            = Digest::SHA256.hexdigest uri.sanitize_uri
           @cached        = cache_root + "#{key}.cached"
           @etag          = cache_root + "#{key}.etag"
           @last_modified = cache_root + "#{key}.last_modified"


### PR DESCRIPTION
This fixes the problem with long URI's used for downloading external dependencies causing filenames being generated that exceeds File System Limits.
'.bin' Files need some special treatment because the code for using the ibmjdk has some built-in checks that rely on the original Filename to be able to expand the JRE. 
https://github.com/cloudfoundry/ibm-websphere-liberty-buildpack/blob/faf82f716e9ba6e3ed128ceabee131747cd9299b/lib/liberty_buildpack/jre/ibmjdk.rb#L131
 