### PR TITLE
Fix rubocop error

### DIFF
--- a/lib/liberty_buildpack/framework/ca_apm_agent.rb
+++ b/lib/liberty_buildpack/framework/ca_apm_agent.rb
@@ -174,7 +174,7 @@ module LibertyBuildpack::Framework
     end
 
     def agent_startup_delay_credential(java_opts, credentials)
-      java_opts << "-Dcom.wily.introscope.agent.startup.mode=neo"
+      java_opts << '-Dcom.wily.introscope.agent.startup.mode=neo'
       credential = credentials['com_wily_introscope_agent_startup_delay']
       java_opts << "-Dcom.wily.introscope.agent.startup.delay=#{credential}" if credential
     end


### PR DESCRIPTION
    [exec] lib/liberty_buildpack/framework/ca_apm_agent.rb:177:20: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
     [exec]       java_opts << "-Dcom.wily.introscope.agent.startup.mode=neo"