### PR TITLE
fix expect

### DIFF
--- a/spec/liberty_buildpack/framework/ca_apm_agent_spec.rb
+++ b/spec/liberty_buildpack/framework/ca_apm_agent_spec.rb
@@ -156,7 +156,7 @@ module LibertyBuildpack::Framework
                                         'credentials' => { 'agent_manager_url' => 'localhost:5001' } }] } do
 
         java_opts = released
-        expect(java_opts).to include("-javaagent:./#{ca_apm_home}/wily/Agent.jar")
+        expect(java_opts).to include("-javaagent:./#{ca_apm_home}/wily/AgentNoRedefNoRetrans.jar")
         expect(java_opts).to include('-Dorg.osgi.framework.bootdelegation=com.wily.*')
         expect(java_opts).to include(/-Dcom.wily.introscope.agentProfile=.*\/wily\/core\/config\/IntroscopeAgent.profile/)
         expect(java_opts).to include('-Dintroscope.agent.hostName=liberty_app.example.com')
@@ -175,7 +175,7 @@ module LibertyBuildpack::Framework
                                          'credentials' => { 'agent_manager_url' => 'localhost:5001', 'agent_manager_credential' => 'test1234abcdf' } }] } do
 
         java_opts = released
-        expect(java_opts).to include("-javaagent:./#{ca_apm_home}/wily/Agent.jar")
+        expect(java_opts).to include("-javaagent:./#{ca_apm_home}/wily/AgentNoRedefNoRetrans.jar")
         expect(java_opts).to include('-Dorg.osgi.framework.bootdelegation=com.wily.*')
         expect(java_opts).to include(/-Dcom.wily.introscope.agentProfile=.*\/wily\/core\/config\/IntroscopeAgent.profile/)
         expect(java_opts).to include('-Dintroscope.agent.hostName=liberty_app.example.com')


### PR DESCRIPTION
[exec] Failures:
     [exec] 
     [exec]   1) CA APM Agent  release should return java command line options for the introscope service
     [exec]      Failure/Error: expect(java_opts).to include("-javaagent:./#{ca_apm_home}/wily/Agent.jar")
     [exec]        expected ["-javaagent:./.ca_apm/wily/AgentNoRedefNoRetrans.jar", "-Dorg.osgi.framework.bootdelegation=com.wily...engard.postofficehub.link.net.DefaultSocketFactory", "-Dcom.wily.introscope.agent.startup.mode=neo"] to include "-javaagent:./.ca_apm/wily/Agent.jar"
     [exec]      # ./spec/liberty_buildpack/framework/ca_apm_agent_spec.rb:159:in `block (3 levels) in <module:Framework>'
     [exec] 
     [exec]   2) CA APM Agent  release should return java command line options for the introscope service and have the agent manager credential if present
     [exec]      Failure/Error: expect(java_opts).to include("-javaagent:./#{ca_apm_home}/wily/Agent.jar")
     [exec]        expected ["-javaagent:./.ca_apm/wily/AgentNoRedefNoRetrans.jar", "-Dorg.osgi.framework.bootdelegation=com.wily...Factory", "-DagentManager.credential=test1234abcdf", "-Dcom.wily.introscope.agent.startup.mode=neo"] to include "-javaagent:./.ca_apm/wily/Agent.jar"
     [exec]      # ./spec/liberty_buildpack/framework/ca_apm_agent_spec.rb:178:in `block (3 levels) in <module:Framework>'