### PR TITLE
Due to stability issues, changed back to use AgentNoRedefNoRetrans.jar.

### DIFF
--- a/lib/liberty_buildpack/framework/ca_apm_agent.rb
+++ b/lib/liberty_buildpack/framework/ca_apm_agent.rb
@@ -76,11 +76,11 @@ module LibertyBuildpack::Framework
     def release
       app_dir = @common_paths.relative_location
       ca_apm_home_dir = File.join(app_dir, CA_APM_HOME_DIR)
-      ca_apm_agent = File.join(ca_apm_home_dir, 'wily/Agent.jar')
+      ca_apm_agent = File.join(ca_apm_home_dir, 'wily/AgentNoRedefNoRetrans.jar')
 
       @java_opts << "-javaagent:#{ca_apm_agent}"
       @java_opts << '-Dorg.osgi.framework.bootdelegation=com.wily.*'
-      @java_opts << "-Dcom.wily.introscope.agentProfile=#{ca_apm_home_dir}/wily/core/config/IntroscopeAgent.profile"
+      @java_opts << "-Dcom.wily.introscope.agentProfile=#{ca_apm_home_dir}/wily/core/config/IntroscopeAgent.NoRedef.profile"
       credentials = @services.find_service(FILTER)['credentials']
 
       agent_host_name @java_opts

--- a/spec/liberty_buildpack/framework/ca_apm_agent_spec.rb
+++ b/spec/liberty_buildpack/framework/ca_apm_agent_spec.rb
@@ -39,7 +39,7 @@ module LibertyBuildpack::Framework
       # defaults
       else
         index_version = version
-        index_uri = "https://ca.bintray.com/websphere/IntroscopeAgentFiles-NoInstaller#{version}websphere.unix.tar"
+        index_uri = "https://packages.broadcom.com/artifactory/websphere/IntroscopeAgentFiles-NoInstaller#{version}websphere.unix.tar"
       end
 
       # By default, always stub the return of a valid index.yml entry
@@ -123,7 +123,7 @@ module LibertyBuildpack::Framework
 
       describe 'download agent tar based on index.yml' do
         it 'should download the agent tar based on the version key' do
-          expect { compiled }.to output(%r{ Downloading CA APM Agent #{version} from https://ca.bintray.com/websphere/IntroscopeAgentFiles-NoInstaller#{version}websphere.unix.tar }).to_stdout
+          expect { compiled }.to output(%r{ Downloading CA APM Agent #{version} from https://packages.broadcom.com/artifactory/websphere/IntroscopeAgentFiles-NoInstaller#{version}websphere.unix.tar }).to_stdout
         end
       end
     end
@@ -156,9 +156,9 @@ module LibertyBuildpack::Framework
                                         'credentials' => { 'agent_manager_url' => 'localhost:5001' } }] } do
 
         java_opts = released
-        expect(java_opts).to include("-javaagent:./#{ca_apm_home}/wily/Agent.jar")
+        expect(java_opts).to include("-javaagent:./#{ca_apm_home}/wily/AgentNoRedefNoRetrans.jar")
         expect(java_opts).to include('-Dorg.osgi.framework.bootdelegation=com.wily.*')
-        expect(java_opts).to include(/-Dcom.wily.introscope.agentProfile=.*\/wily\/core\/config\/IntroscopeAgent.profile/)
+        expect(java_opts).to include(/-Dcom.wily.introscope.agentProfile=.*\/wily\/core\/config\/IntroscopeAgent.NoRedef.profile/)
         expect(java_opts).to include('-Dintroscope.agent.hostName=liberty_app.example.com')
         expect(java_opts).to include('-Dintroscope.agent.agentName=liberty_app')
         expect(java_opts).to include('-DagentManager.url.1=localhost:5001')
@@ -175,9 +175,9 @@ module LibertyBuildpack::Framework
                                          'credentials' => { 'agent_manager_url' => 'localhost:5001', 'agent_manager_credential' => 'test1234abcdf' } }] } do
 
         java_opts = released
-        expect(java_opts).to include("-javaagent:./#{ca_apm_home}/wily/Agent.jar")
+        expect(java_opts).to include("-javaagent:./#{ca_apm_home}/wily/AgentNoRedefNoRetrans.jar")
         expect(java_opts).to include('-Dorg.osgi.framework.bootdelegation=com.wily.*')
-        expect(java_opts).to include(/-Dcom.wily.introscope.agentProfile=.*\/wily\/core\/config\/IntroscopeAgent.profile/)
+        expect(java_opts).to include(/-Dcom.wily.introscope.agentProfile=.*\/wily\/core\/config\/IntroscopeAgent.NoRedef.profile/)
         expect(java_opts).to include('-Dintroscope.agent.hostName=liberty_app.example.com')
         expect(java_opts).to include('-Dintroscope.agent.agentName=liberty_app')
         expect(java_opts).to include('-DagentManager.url.1=localhost:5001')


### PR DESCRIPTION
We need to change back to use AgenNoRedefNoRetrans.jar, because Agent.jar has stability issues when using with IBM JVM.  

Please see below, the spec tests were passed. 

..........................................................................................................................................................................

Finished in 6 minutes 58 seconds (files took 0.49562 seconds to load)
798 examples, 0 failures

Randomized with seed 31003

Coverage report Rcov style generated for RSpec to /pcf/ibm-websphere-liberty-buildpack/coverage/rcov