### PR TITLE
Revert "Bump rack from 2.2.6.4 to 2.2.8.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
       ast (~> 2.4.1)
     powerpack (0.1.3)
     public_suffix (5.0.1)
-    rack (2.2.8.1)
+    rack (2.2.6.4)
     rack-protection (2.2.4)
       rack
     rainbow (2.1.0)


### PR DESCRIPTION
Reverts cloudfoundry/ibm-websphere-liberty-buildpack#602