### PR TITLE
Revert "Bump yard from 0.9.34 to 0.9.35"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.35)
+    yard (0.9.34)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Reverts cloudfoundry/ibm-websphere-liberty-buildpack#601